### PR TITLE
Add proper Paging to Get functions

### DIFF
--- a/ConfluencePS/Private/Invoke-WikiMethod.ps1
+++ b/ConfluencePS/Private/Invoke-WikiMethod.ps1
@@ -3,8 +3,16 @@ function Invoke-WikiMethod {
     .SYNOPSIS
     Extracted invokation of the REST method to own function.
     #>
-    [CmdletBinding()]
-    [OutputType( [PSObject] )]
+    [CmdletBinding(SupportsPaging = $true)]
+    [OutputType(
+        [PSObject],
+        [ConfluencePS.Page],
+        [ConfluencePS.Space],
+        [ConfluencePS.Label],
+        [ConfluencePS.Icon],
+        [ConfluencePS.Version],
+        [ConfluencePS.User]
+    )]
     param (
         # REST API to invoke
         [Parameter(Mandatory = $true)]
@@ -19,10 +27,10 @@ function Invoke-WikiMethod {
         [string]$Body,
 
         # Additional headers
-        [hashtable]$Headers,
+        [Hashtable]$Headers,
 
         # GET Parameters
-        [hashtable]$GetParameters,
+        [Hashtable]$GetParameters,
 
         # Type of object to which the output will be casted to
         [ValidateSet(
@@ -60,12 +68,15 @@ function Invoke-WikiMethod {
             ))
         $_headers += @{
             "Authorization" = "Basic $($SecureCreds)"
-            'Content-Type' = 'application/json; charset=utf-8'
+            'Content-Type'  = 'application/json; charset=utf-8'
         }
     }
 
     Process {
         # Append GET parameters to URi
+        if (($PSCmdlet.PagingParameters) -and ($PSCmdlet.PagingParameters.Skip)) {
+            $GetParameters["start"] = $PSCmdlet.PagingParameters.Skip
+        }
         if ($GetParameters) {
             Write-Debug "Using `$GetParameters: $($GetParameters | Out-String)"
             [string]$URI += (ConvertTo-GetParameter $GetParameters)
@@ -75,11 +86,11 @@ function Invoke-WikiMethod {
 
         # set mandatory parameters
         $splatParameters = @{
-            Uri = $URi
-            Method = $Method
-            Headers = $_headers
+            Uri             = $URi
+            Method          = $Method
+            Headers         = $_headers
             UseBasicParsing = $true
-            ErrorAction = 'SilentlyContinue'
+            ErrorAction     = 'SilentlyContinue'
         }
 
         # set optional parameters
@@ -111,7 +122,7 @@ function Invoke-WikiMethod {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Status code: $($webResponse.StatusCode)"
 
             if ($webResponse.StatusCode.value__ -ge 400) {
-                Write-Warning "Conflunce returned HTTP error $($webResponse.StatusCode.value__) - $($webResponse.StatusCode)"
+                Write-Warning "Confluence returned HTTP error $($webResponse.StatusCode.value__) - $($webResponse.StatusCode)"
 
                 # Retrieve body of HTTP response - this contains more useful information about exactly why the error occurred
                 $readStream = New-Object -TypeName System.IO.StreamReader -ArgumentList ($webResponse.GetResponseStream())
@@ -134,61 +145,52 @@ function Invoke-WikiMethod {
                 if ($webResponse.Content) {
                     # API returned a Content: lets work wit it
                     $result = ConvertFrom-Json -InputObject $webResponse.Content
+
+                    if ($result.errors -ne $null) {
+                        Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received from; resolving"
+                        # This could be handled nicely in an function such as:
+                        # ResolveError $result -WriteError
+                        Write-Error $($result.errors | Out-String)
+                    }
+                    else {
+                        if ($PSCmdlet.PagingParameters.IncludeTotalCount) {
+                            [double]$Accuracy = 1.0
+                            $PSCmdlet.PagingParameters.NewTotalCount($result.size, $Accuracy)
+                        }
+                        # None paginated results / first page of pagination
+                        if (($result) -and ($result | Get-Member -Name results)) {
+                            $result = $result.results
+                        }
+                        if ($OutputType) {
+                            # Results shall be casted to custom objects (see ValidateSet)
+                            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Outputting results as $($OutputType.FullName)"
+                            $converter = "ConvertTo-Wiki$($OutputType.Name)"
+                            $result | & $converter
+                        }
+                        else {
+                            $result
+                        }
+
+                        # Detect if result is paginated
+                        if ($result._links.next) {
+                            Write-Verbose "[Invoke-WikiMethod] Invoking pagination"
+
+                            # Self-Invoke function for recursion
+                            $parameters = @{
+                                URi    = "{0}{1}" -f $result._links.base, $result._links.next
+                                Method = $Method
+                            }
+                            if ($Body) {$parameters["Body"] = $Body}
+                            if ($Headers) {$parameters["Headers"] = $Headers}
+
+                            Invoke-WikiMethod @parameters
+                        }
+                    }
                 }
                 else {
                     # No content, although statusCode < 400
                     # This could be wanted behavior of the API
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] No content was returned from."
-                }
-            }
-
-            if ($result.errors -ne $null) {
-                Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received from; resolving"
-                # This could be handled nicely in an function such as:
-                # ResolveError $result -WriteError
-                Write-Error $($result.errors | Out-String)
-            }
-            else {
-                # Detect if result is paginated
-                if ($result._links.next) {
-                    Write-Verbose "[$($MyInvocation.MyCommand.Name)] Invoking pagination"
-
-                    # Self-Invoke function for recursion
-                    $parameters = @{
-                        URi = "{0}{1}" -f $result._links.base, $result._links.next
-                        Method = $Method
-                    }
-                    if ($Body) {$parameters["Body"] = $Body}
-                    if ($Headers) {$parameters["Headers"] = $Headers}
-
-                    # Append results
-                    $result.results += (Invoke-WikiMethod @parameters)
-                }
-
-                # Extract results from array
-                # This allows for harmonized handling of single or multiple results
-                if (($result) -and ($result | Get-Member -Name results)) {
-                    $result = $result | Select-Object -ExpandProperty results
-                }
-
-                if ($OutputType) {
-                    # Results shall be casted to custom objects (see ValidateSet)
-                    Write-Verbose "[$($MyInvocation.MyCommand.Name)] Outputting results as $($OutputType.FullName)"
-                    $convertFunction = "ConvertTo-Wiki$($OutputType.Name)"
-
-                    # We need to test if there is 1+ result to convert
-                    # If not, we would return an empty object
-                    if (($result | Measure-Object).count -ge 1) {
-                        foreach ($item in $result) {
-                            # Use private function `ConvertTo-Wiki<ObjectName>` to cast objects
-                            Write-Output ($item | & $convertFunction)
-                        }
-                    }
-                }
-                else {
-                    # Return results as PSCustomObject
-                    Write-Verbose "[$($MyInvocation.MyCommand.Name)] Outputting results as PSCustomObject"
-                    Write-Output $result
                 }
             }
         }

--- a/ConfluencePS/Private/Invoke-WikiMethod.ps1
+++ b/ConfluencePS/Private/Invoke-WikiMethod.ps1
@@ -69,6 +69,8 @@ function Invoke-WikiMethod {
         if ($GetParameters) {
             Write-Debug "Using `$GetParameters: $($GetParameters | Out-String)"
             [string]$URI += (ConvertTo-GetParameter $GetParameters)
+            # Prevent recursive appends
+            $GetParameters = $null
         }
 
         # set mandatory parameters
@@ -99,7 +101,7 @@ function Invoke-WikiMethod {
             # Invoke-WebRequest is hard-coded to throw an exception if the Web request returns a 4xx or 5xx error.
             # This is the best workaround I can find to retrieve the actual results of the request.
             # This shall be fixed with PoSh v6: https://github.com/PowerShell/PowerShell/issues/2193
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an anser from the server"
+            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
             $webResponse = $_.Exception.Response
         }
 
@@ -147,7 +149,7 @@ function Invoke-WikiMethod {
                 Write-Error $($result.errors | Out-String)
             }
             else {
-                # Dected if result is paginated
+                # Detect if result is paginated
                 if ($result._links.next) {
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Invoking pagination"
 
@@ -158,7 +160,6 @@ function Invoke-WikiMethod {
                     }
                     if ($Body) {$parameters["Body"] = $Body}
                     if ($Headers) {$parameters["Headers"] = $Headers}
-                    if ($GetParameters) {$parameters["GetParameters"] = $GetParameters}
 
                     # Append results
                     $result.results += (Invoke-WikiMethod @parameters)

--- a/ConfluencePS/Private/Invoke-WikiMethod.ps1
+++ b/ConfluencePS/Private/Invoke-WikiMethod.ps1
@@ -188,6 +188,7 @@ function Invoke-WikiMethod {
                             }
                             if ($Body) {$parameters["Body"] = $Body}
                             if ($Headers) {$parameters["Headers"] = $Headers}
+                            if ($OutputType) {$parameters["OutputType"] = $OutputType}
 
                             Write-Verbose "NEXT PAGE: $($parameters["URi"])"
 

--- a/ConfluencePS/Public/Get-WikiChildPage.ps1
+++ b/ConfluencePS/Public/Get-WikiChildPage.ps1
@@ -27,7 +27,10 @@
     .LINK
     https://github.com/brianbunke/ConfluencePS
     #>
-    [CmdletBinding(DefaultParameterSetName = "byID")]
+    [CmdletBinding(
+        SupportsPaging = $true,
+        DefaultParameterSetName = "byID"
+    )]
     [OutputType([ConfluencePS.Page])]
     param (
         # The URi of the API interface.
@@ -75,6 +78,11 @@
             $message = "The Object in the pipe is not a Page."
             $exception = New-Object -TypeName System.ArgumentException -ArgumentList $message
             Throw $exception
+        }
+
+        # Paging
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+            $script:PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
         }
 
         if ($PsCmdlet.ParameterSetName -eq "byObject") {

--- a/ConfluencePS/Public/Get-WikiChildPage.ps1
+++ b/ConfluencePS/Public/Get-WikiChildPage.ps1
@@ -8,6 +8,17 @@
 
     This API method only returns the immediate children (results are not recursive).
 
+    .PARAMETER Skip
+    Controls how many things will be skipped before starting output. Defaults to 0.
+
+    .PARAMETER First
+    Currently not supported.
+    Indicates how many items to return. Defaults to 100.
+
+    .PARAMETER IncludeTotalCount
+    Causes an extra output of the total count at the beginning.
+    Note this is actually a uInt64, but with a custom string representation.
+
     .EXAMPLE
     Get-WikiChildPage -ParentID 1234 | Select-Object ID, Title | Sort-Object Title
     For the wiki page with ID 1234, get all pages immediately beneath it.

--- a/ConfluencePS/Public/Get-WikiLabel.ps1
+++ b/ConfluencePS/Public/Get-WikiLabel.ps1
@@ -6,6 +6,17 @@
     .DESCRIPTION
     View all labels applied to a content.
 
+    .PARAMETER Skip
+    Controls how many things will be skipped before starting output. Defaults to 0.
+
+    .PARAMETER First
+    Currently not supported.
+    Indicates how many items to return. Defaults to 100.
+
+    .PARAMETER IncludeTotalCount
+    Causes an extra output of the total count at the beginning.
+    Note this is actually a uInt64, but with a custom string representation.
+
     .EXAMPLE
     Get-WikiLabel -PageID 123456 -PageSize 500 -ApiURi "https://myserver.com/wiki" -Credential $cred
     Lists the labels applied to page 123456.

--- a/ConfluencePS/Public/Get-WikiLabel.ps1
+++ b/ConfluencePS/Public/Get-WikiLabel.ps1
@@ -20,7 +20,9 @@
     .LINK
     https://github.com/brianbunke/ConfluencePS
     #>
-    [CmdletBinding()]
+    [CmdletBinding(
+        SupportsPaging = $true
+    )]
     [OutputType([ConfluencePS.ContentLabelSet])]
     param (
         # The URi of the API interface.
@@ -65,6 +67,11 @@
             Throw $exception
         }
 
+        # Paging
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+            $script:PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
+        }
+
         foreach ($_page in $PageID) {
             if ($_ -is [ConfluencePS.Page]) {
                 $InputObject = $_
@@ -74,7 +81,8 @@
             }
 
             $URI = "$apiURi/content/{0}/label" -f $_page
-            If ($PageSize) { $GETparameters = @{limit = $PageSize} }
+            If ($PageSize) { $GETparameters = @{limit = $PageSize}
+            }
 
             $output = New-Object -TypeName ConfluencePS.ContentLabelSet -Property @{
                 Page = $InputObject

--- a/ConfluencePS/Public/Get-WikiPage.ps1
+++ b/ConfluencePS/Public/Get-WikiPage.ps1
@@ -7,6 +7,17 @@
     Fetch Confluence pages, optionally filtering by Name/Space/ID.
     Piped output into other cmdlets is generally tested and supported.
 
+    .PARAMETER Skip
+    Controls how many things will be skipped before starting output. Defaults to 0.
+
+    .PARAMETER First
+    Currently not supported.
+    Indicates how many items to return. Defaults to 100.
+
+    .PARAMETER IncludeTotalCount
+    Causes an extra output of the total count at the beginning.
+    Note this is actually a uInt64, but with a custom string representation.
+
     .EXAMPLE
     Get-WikiPage -ApiURi "https://myserver.com/wiki" -Credential $cred | Select-Object ID, Title -first 500 | Sort-Object Title
     List the first 500 pages found in your Confluence instance.
@@ -38,7 +49,10 @@
     .LINK
     https://github.com/brianbunke/ConfluencePS
     #>
-    [CmdletBinding(DefaultParameterSetName = "byId")]
+    [CmdletBinding(
+        SupportsPaging = $true,
+        DefaultParameterSetName = "byId"
+    )]
     [OutputType([ConfluencePS.Page])]
     param (
         # The URi of the API interface.
@@ -129,6 +143,11 @@
 
         $resourceURI = "$apiURi/content"
         $GETparameters = @{expand = "space,version,body.storage,ancestors"}
+
+        # Paging
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+            $PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
+        }
 
         switch -regex ($PsCmdlet.ParameterSetName) {
             "byId" {

--- a/ConfluencePS/Public/Get-WikiPage.ps1
+++ b/ConfluencePS/Public/Get-WikiPage.ps1
@@ -71,7 +71,8 @@
             Position = 0,
             Mandatory = $true,
             ParameterSetName = "byId",
-            ValueFromPipeline = $true
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true
         )]
         [ValidateRange(1, [int]::MaxValue)]
         [Alias('ID')]
@@ -146,7 +147,7 @@
 
         # Paging
         ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
-            $PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
+            $script:PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
         }
 
         switch -regex ($PsCmdlet.ParameterSetName) {

--- a/ConfluencePS/Public/Get-WikiSpace.ps1
+++ b/ConfluencePS/Public/Get-WikiSpace.ps1
@@ -8,6 +8,17 @@
     Input for all parameters is not case sensitive.
     Piped output into other cmdlets is generally tested and supported.
 
+    .PARAMETER Skip
+    Controls how many things will be skipped before starting output. Defaults to 0.
+
+    .PARAMETER First
+    Currently not supported.
+    Indicates how many items to return. Defaults to 100.
+
+    .PARAMETER IncludeTotalCount
+    Causes an extra output of the total count at the beginning.
+    Note this is actually a uInt64, but with a custom string representation.
+
     .EXAMPLE
     Get-WikiSpace -ApiURi "https://myserver.com/wiki" -Credential $cred
     Display the info of all spaces on the server.

--- a/ConfluencePS/Public/Get-WikiSpace.ps1
+++ b/ConfluencePS/Public/Get-WikiSpace.ps1
@@ -19,7 +19,9 @@
     .LINK
     https://github.com/brianbunke/ConfluencePS
     #>
-    [CmdletBinding()]
+    [CmdletBinding(
+        SupportsPaging = $true
+    )]
     [OutputType([ConfluencePS.Space])]
     param (
         # The URi of the API interface.
@@ -57,6 +59,11 @@
         $resourceURI = "$apiURi/space"
         $GETparameters += @{expand = "description.plain,icon,homepage,metadata.labels"}
         If ($PageSize) { $GETparameters["limit"] = $PageSize }
+
+        # Paging
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+            $script:PSDefaultParameterValues["Invoke-WikiMethod:$_"] = $PSCmdlet.PagingParameters.$_
+        }
 
         if ($SpaceKey) {
             foreach ($_space in $SpaceKey) {


### PR DESCRIPTION
This implementation add proper Paging to `Invoke-WikiMethod`.
If a `-PageSize` is defined (25 by default), `Invoke-WikiMethod` will request only that many results from the server.
`Invoke-WikiMethod` will then look in the response, if there are more pages with results available.
As long as there is a _next page_, `Invoke-WikiMethod` will self-invoke to retrieve the data.

This allows for better pipeline handling:
* `| Select -First 10` will not wait for all results, but rather until enough results are available to select _10_
* `Get-WikiPage -SpaceKey ABC | Remove-WikiPage`: `Remove-WikiPage` can start processing before all pages were received by `Get-WikiPage`

If the user wants to get all and store in a variable, a high `-PageSize` is recommended
If the user wants to "stream" the output over the pipeline, a low `-PageSize` is recommended


Further, all exposed functions that return collections now expose _Paging_ parameters.
See the .PARAMETER section of the function for more information

This implements and closes #50