### PR TITLE
Enhance: ConvertTo-ConfluenceStorageFormat support multiple strings

### DIFF
--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -13,7 +13,7 @@
             Mandatory = $true,
             ValueFromPipeline = $true
         )]
-        [string]$Content
+        [string[]]$Content
     )
 
     BEGIN {
@@ -24,18 +24,20 @@
         Write-Debug "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-Debug "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        $iwParameters = @{
-            Uri        = "$apiURi/contentbody/convert/storage"
-            Method     = 'Post'
-            Body       = @{
-                value          = "$Content"
-                representation = 'wiki'
-            } | ConvertTo-Json
-            Credential = $Credential
-        }
+        foreach ($_content in $Content) {
+            $iwParameters = @{
+                Uri        = "$apiURi/contentbody/convert/storage"
+                Method     = 'Post'
+                Body       = @{
+                    value          = "$_content"
+                    representation = 'wiki'
+                } | ConvertTo-Json
+                Credential = $Credential
+            }
 
-        Write-Debug "[$($MyInvocation.MyCommand.Name)] Content to be sent: $($Content | Out-String)"
-        (Invoke-Method @iwParameters).value
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Content to be sent: $($_content | Out-String)"
+            (Invoke-Method @iwParameters).value
+        }
     }
 
     END {

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -203,15 +203,18 @@ InModuleScope ConfluencePS {
         # ACT
         $result1 = $inputString | ConvertTo-ConfluenceStorageFormat
         $result2 = ConvertTo-ConfluenceStorageFormat -Content $inputString
+        $result3 = ConvertTo-ConfluenceStorageFormat -Content $inputString, $inputString
 
         # ASSERT
         It 'returns a string' {
             $result1 | Should BeOfType [String]
             $result2 | Should BeOfType [String]
+            $result3 | Should BeOfType [String]
         }
         It 'output matches the expected string' {
             $result1 | Should BeExactly $outputString
             $result2 | Should BeExactly $outputString
+            $result3 | Should BeExactly @($outputString, $outputString)
         }
     }
 

--- a/docs/en-US/ConvertTo-StorageFormat.md
+++ b/docs/en-US/ConvertTo-StorageFormat.md
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 A string (in plain text and/or wiki markup) to be converted to storage format.
 
 ```yaml
-Type: String
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 


### PR DESCRIPTION
### Description
Allow `ConvertTo-ConfluenceStorageFormat` to get multiple strings as input

### Motivation and Context
closes #77

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
