### PR TITLE
Fix: Piping to Get-ConfluencePage

### DIFF
--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -45,6 +45,7 @@
         [Parameter(
             Mandatory = $true,
             ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             ParameterSetName = "bySpaceObject"
         )]
         [Parameter(

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -328,6 +328,7 @@ InModuleScope ConfluencePS {
         $GetKeys = Get-ConfluencePage -SpaceKey $SpaceKey | Sort ID -ErrorAction SilentlyContinue
         $GetByLabel = Get-ConfluencePage -Label "important" -ErrorAction SilentlyContinue
         $GetSpacePage = Get-ConfluencePage -Space (Get-ConfluenceSpace -SpaceKey $SpaceKey) -ErrorAction SilentlyContinue
+        $GetSpacePiped = Get-ConfluenceSpace -SpaceKey $SpaceKey | Get-ConfluencePage -ErrorAction SilentlyContinue
 
         # ASSERT
         It 'returns the correct amount of results' {
@@ -338,6 +339,7 @@ InModuleScope ConfluencePS {
             $GetKeys.Count | Should Be 5
             $GetByLabel.Count | Should Be 1
             $GetSpacePage.Count | Should Be 5
+            $GetSpacePiped.Count | Should Be 5
         }
         It 'returns an object with specific properties' {
             $GetTitle1 | Should BeOfType [ConfluencePS.Page]


### PR DESCRIPTION
### Description
Filter results from `Get-Page` by piping space objects from `Get-Space`.

### Motivation and Context
Resolves #75.

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
