### PR TITLE
Update cmdlet-based help files

### DIFF
--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -23,8 +23,10 @@
         [int[]]$PageID,
 
         [Parameter(
-            Mandatory = $true,
-            ParameterSetName = "byTitle"
+            ParameterSetName = "bySpace"
+        )]
+        [Parameter(
+            ParameterSetName = "bySpaceObject"
         )]
         [Alias('Name')]
         [string]$Title,
@@ -32,9 +34,6 @@
         [Parameter(
             Mandatory = $true,
             ParameterSetName = "bySpace"
-        )]
-        [Parameter(
-            ParameterSetName = "byTitle"
         )]
         [Parameter(
             ParameterSetName = "byLabel"
@@ -47,10 +46,6 @@
             ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true,
             ParameterSetName = "bySpaceObject"
-        )]
-        [Parameter(
-            ValueFromPipeline = $true,
-            ParameterSetName = "byTitle"
         )]
         [Parameter(
             ValueFromPipeline = $true,
@@ -107,12 +102,12 @@
                 }
                 break
             }
-            "(bySpace|byTitle)" {
+            "bySpace" { # This includes 'bySpaceObject'
                 $iwParameters["Uri"] = $resourceApi -f ''
                 $iwParameters["GetParameters"]["type"] = "page"
                 if ($SpaceKey) { $iwParameters["GetParameters"]["spaceKey"] = $SpaceKey }
 
-                if ($PsCmdlet.ParameterSetName -eq 'byTitle') {
+                if ($Title) {
                     Invoke-Method @iwParameters | Where-Object {$_.Title -like "$Title"}
                 }
                 else {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -113,7 +113,7 @@
                 if ($SpaceKey) { $iwParameters["GetParameters"]["spaceKey"] = $SpaceKey }
 
                 if ($PsCmdlet.ParameterSetName -eq 'byTitle') {
-                    Invoke-Method @iwParameters | Where-Object {$_.Title -like "*$Title*"}
+                    Invoke-Method @iwParameters | Where-Object {$_.Title -like "$Title"}
                 }
                 else {
                     Invoke-Method @iwParameters

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -323,7 +323,7 @@ InModuleScope ConfluencePS {
         Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
         # ACT
-        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -PageSize 200 -ErrorAction SilentlyContinue
+        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
         $GetTitle2   = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetPartial  = Get-ConfluencePage -Title $Title4 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetWildcard = Get-ConfluencePage -Title $Title5 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
@@ -436,7 +436,7 @@ InModuleScope ConfluencePS {
     Describe 'Add-ConfluenceLabel' {
         # ARRANGE
         $SpaceKey = "PESTER"
-        $Page1 = Get-ConfluencePage -Title "Pester New Page Piped" -ErrorAction Stop
+        $Page1 = Get-ConfluencePage -Title "Pester New Page Piped" -SpaceKey $SpaceKey -ErrorAction Stop
         $Label1 = [string[]]("pestera", "pesterb", "pesterc")
         $Label2 = "pesterall"
         $PartialLabel = "pest"
@@ -480,10 +480,11 @@ InModuleScope ConfluencePS {
 
     Describe 'Set-ConfluenceLabel' {
         # ARRANGE
+        $SpaceKey = "PESTER"
         $Title1 = "Pester New Page from Object"
         $Label1 = @("overwrite", "remove")
         $Label2 = "final"
-        $Page1 = Get-ConfluencePage -Title $Title1 -ErrorAction SilentlyContinue
+        $Page1 = Get-ConfluencePage -Title $Title1 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $Before1 = $Page1 | Get-ConfluenceLabel
 
         # ACT
@@ -522,7 +523,7 @@ InModuleScope ConfluencePS {
         $SpaceKey = "PESTER"
         $patternLabel1 = "pester[abc]$"
         $patternLabel2 = "(pest|import|fin)"
-        $Page = Get-ConfluencePage -Title "Pester New Page Piped"
+        $Page = Get-ConfluencePage -Title "Pester New Page Piped" -SpaceKey $SpaceKey
 
         # ACT
         $GetPageLabel1 = Get-ConfluenceLabel -PageID $Page.ID
@@ -743,10 +744,11 @@ InModuleScope ConfluencePS {
         }
     }
 
-Describe 'Remove-ConfluenceLabel' {
+    Describe 'Remove-ConfluenceLabel' {
         # ARRANGE
+        $SpaceKey = "PESTER"
         $Label1 = "pesterc"
-        $Page1 = Get-ConfluencePage -Title 'Pester New Page Piped' -ErrorAction Stop
+        $Page1 = Get-ConfluencePage -Title 'Pester New Page Piped' -SpaceKey $SpaceKey -ErrorAction Stop
         $Page2 = (Get-ConfluenceSpace -SpaceKey PESTER).Homepage
 
         # ACT
@@ -772,7 +774,7 @@ Describe 'Remove-ConfluenceLabel' {
         # ARRANGE
         $SpaceKey = "PESTER"
         $Title = "Pester New Page Orphan"
-        $PageID = Get-ConfluencePage -Title $Title -ErrorAction Stop
+        $PageID = Get-ConfluencePage -Title $Title -SpaceKey $SpaceKey -ErrorAction Stop
         $Before = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction Stop
 
         # ACT

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -316,13 +316,17 @@ InModuleScope ConfluencePS {
         $Title1 = "Pester New Page from Object"
         $Title2 = "Pester New Page Orphan"
         $Title3 = "Pester Test Space Home"
+        $Title4 = "orphan"
+        $Title5 = "*orphan"
         $Content = "<p>Hi Pester!</p>"
         (Get-ConfluenceSpace -SpaceKey $SpaceKey).Homepage | Add-ConfluenceLabel -Label "important" -ErrorAction Stop
         Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
         # ACT
-        $GetTitle1 = Get-ConfluencePage -Title $Title1.ToLower() -PageSize 200 -ErrorAction SilentlyContinue
-        $GetTitle2 = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -PageSize 200 -ErrorAction SilentlyContinue
+        $GetTitle2   = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+        $GetPartial  = Get-ConfluencePage -Title $Title4 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+        $GetWildcard = Get-ConfluencePage -Title $Title5 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetID1 = Get-ConfluencePage -PageID $GetTitle1.ID -ErrorAction SilentlyContinue
         $GetID2 = Get-ConfluencePage -PageID $GetTitle2.ID -ErrorAction SilentlyContinue
         $GetKeys = Get-ConfluencePage -SpaceKey $SpaceKey | Sort ID -ErrorAction SilentlyContinue
@@ -334,6 +338,8 @@ InModuleScope ConfluencePS {
         It 'returns the correct amount of results' {
             $GetTitle1.Count | Should Be 1
             $GetTitle2.Count | Should Be 1
+            $GetPartial.Count | Should BeNullOrEmpty
+            $GetWildcard.Count | Should Be 1
             $GetID1.Count | Should Be 1
             $GetID2.Count | Should Be 1
             $GetKeys.Count | Should Be 5

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -338,7 +338,7 @@ InModuleScope ConfluencePS {
         It 'returns the correct amount of results' {
             $GetTitle1.Count | Should Be 1
             $GetTitle2.Count | Should Be 1
-            $GetPartial.Count | Should BeNullOrEmpty
+            $GetPartial.Count | Should Be 0
             $GetWildcard.Count | Should Be 1
             $GetID1.Count | Should Be 1
             $GetID2.Count | Should Be 1

--- a/docs/en-US/Add-Label.md
+++ b/docs/en-US/Add-Label.md
@@ -4,6 +4,7 @@ online version: https://github.com/AtlassianPS/ConfluencePS/blob/master/docs/en-
 locale: en-US
 schema: 2.0.0
 ---
+
 # Add-Label
 
 ## SYNOPSIS
@@ -16,8 +17,9 @@ Add-ConfluenceLabel -apiURi <Uri> -Credential <PSCredential> [[-PageID] <Int32[]
 ```
 
 ## DESCRIPTION
-This allows the assignment of labels (one or more) to one Confluence pages (one or more).
-If the label did not exist previously, it will be created. (Be aware of typos)
+Assign labels (one or more) to Confluence pages (one or more).
+If the label did not exist previously, it will be created.
+Preexisting labels are not affected.
 
 ## EXAMPLES
 

--- a/docs/en-US/Add-Label.md
+++ b/docs/en-US/Add-Label.md
@@ -12,7 +12,7 @@ Add a new global label to an existing Confluence page.
 ## SYNTAX
 
 ```powershell
-Add-Label -apiURi <Uri> -Credential <PSCredential> [[-PageID] <Int32[]>] -Label <Object> [-WhatIf] [-Confirm]
+Add-ConfluenceLabel -apiURi <Uri> -Credential <PSCredential> [[-PageID] <Int32[]>] -Label <Object> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
@@ -23,28 +23,41 @@ If the label did not exist previously, it will be created. (Be aware of typos)
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Add-Label -ApiURi "https://myserver.com/wiki" -Credential $cred -Label alpha,bravo,charlie -PageID 123456 -Verbose
+Add-ConfluenceLabel -PageID 123456 -Label alpha -Verbose
 ```
 
 Description
 
 -----------
 
-Apply the labels alpha, bravo, and charlie to the page with ID 123456.
-(including verbose output)
+Apply the label alpha to the wiki page with ID 123456.
+-Verbose output provides extra technical details, if interested.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 
 ```powershell
-Get-Page -SpaceKey SRV | Add-Label -Label servers -WhatIf
+Get-ConfluencePage -SpaceKey SRV | Add-ConfluenceLabel -Label servers -WhatIf
 ```
 
 Description
 
 -----------
 
-Simulate apply the label "servers" to all pages in the space with key SRV.
-(Simulated because of the -WhatIf flag)
+Simulates applying the label "servers" to all pages in the space with key SRV.
+-WhatIf provides PageIDs of pages that would have been affected.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```powershell
+Get-ConfluencePage -SpaceKey DEMO | Add-ConfluenceLabel -Label abc -Confirm
+```
+
+Description
+
+-----------
+
+Applies the label "abc" to all pages in the space with key DEMO.
+-Confirm prompts Yes/No for each page that would be affected.
 
 ## PARAMETERS
 
@@ -153,9 +166,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Label]()
-[Remove-Label]()
-[Set-Label]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/ConvertTo-StorageFormat.md
+++ b/docs/en-US/ConvertTo-StorageFormat.md
@@ -13,50 +13,37 @@ Convert your content to Confluence's storage format.
 ## SYNTAX
 
 ```powershell
-ConvertTo-StorageFormat -apiURi <Uri> -Credential <PSCredential> [-Content] <String>
+ConvertTo-ConfluenceStorageFormat -apiURi <Uri> -Credential <PSCredential> [-Content] <String>
 ```
 
 ## DESCRIPTION
 To properly create/edit pages, content should be in the proper "XHTML-based" format.
 Invokes a POST call to convert from a "wiki" representation, receiving a "storage" response.
-https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-$Body = ConvertTo-StorageFormat -Content 'Hello world!'
+$Body = ConvertTo-ConfluenceStorageFormat -Content 'Hello world!'
 ```
 
 Description
 
 -----------
 
-Stores the returned value '\<p\>Hello world!\</p\>' in $Body for use in New-ConfluencePage/Set-ConfluencePage/etc.
+Stores the returned value '\<p\>Hello world!\</p\>' in $Body for use
+in New-ConfluencePage/Set-ConfluencePage/etc.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Date -Format s | ConvertTo-StorageFormat -ApiURi "https://myserver.com/wiki" -Credential $cred
+Get-Date -Format s | ConvertTo-ConfluenceStorageFormat
 ```
 
 Description
 
 -----------
 
-Returns the current date/time in sortable format, and converts via pipeline input.
-
-### -------------------------- EXAMPLE 3 --------------------------
-```powershell
-New-ConfluencePage -Title 'Loner Page' -SpaceKey TEST -Body $Body -Convert -Verbose
-```
-
-Description
-
------------
-
-Creates a new page at the root of the specified space (no parent page).
-Need to invoke ConvertTo-StorageFormat on $Body to prep it for page creation.
-(including verbose output)
+Pipe the current date/time in sortable format, returning the converted string.
 
 ## PARAMETERS
 
@@ -117,7 +104,6 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[New-ConfluencePage]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
 
+[Confluence Storage Format](https://confluence.atlassian.com/confcloud/confluence-storage-format-724765084.html)

--- a/docs/en-US/ConvertTo-Table.md
+++ b/docs/en-US/ConvertTo-Table.md
@@ -13,19 +13,21 @@ Convert your content to Confluence's wiki markup table format.
 ## SYNTAX
 
 ```powershell
-ConvertTo-Table [-Content] <Object> [-NoHeader]
+ConvertTo-ConfluenceTable [-Content] <Object> [-NoHeader]
 ```
 
 ## DESCRIPTION
 Formats input as a table with a horizontal header row.
-This wiki formatting is an intermediate step, and would still need ConvertTo-ConfluenceStorageFormat called against it.
+This wiki formatting is an intermediate step, and would still need
+ConvertTo-ConfluenceStorageFormat called against it.
+
 This work is performed locally, and does not perform a REST call.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Service | Select Name,DisplayName,Status -First 10 | ConvertTo-Table
+Get-Service | Select Name,DisplayName,Status -First 10 | ConvertTo-ConfluenceTable
 ```
 
 Description
@@ -36,7 +38,8 @@ List the first ten services on your computer, and convert to a table in Confluen
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-$SvcTable = Get-Service | Select Name,Status -First 10 | ConvertTo-Table | ConvertTo-ConfluenceStorageFormat
+$SvcTable = Get-Service | Select Name,Status -First 10 |
+    ConvertTo-ConfluenceTable | ConvertTo-ConfluenceStorageFormat
 ```
 
 Description
@@ -44,23 +47,24 @@ Description
 -----------
 
 Following Example 1, convert the table from wiki markup format into storage format.
-Store the results in variable $SvcTable for a later New-ConfluencePage/Set-ConfluencePage command.
+Store the results in $SvcTable for a later New-ConfluencePage/etc. command.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```powershell
-Get-Alias | Where {$_.Name.Length -eq 1} | Select CommandType,DisplayName | ConvertTo-Table -NoHeader
+Get-Alias | Where {$_.Name.Length -eq 1} | Select CommandType,DisplayName |
+    ConvertTo-ConfluenceTable -NoHeader
 ```
 
 Description
 
 -----------
 
-Make a table of all the one-character PowerShell aliases, and don't include the header row.
+Make a table of all one-character PowerShell aliases, and don't include the header row.
 
 ## PARAMETERS
 
 ### -Content
-Object array you would like to see displayed as a table on a wiki page.
+The object array you would like to see displayed as a table on a wiki page.
 
 ```yaml
 Type: Object
@@ -75,7 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoHeader
-Ignore the property names, and just have a table of values with no header row highlighting.
+Ignore the property names, keeping a table of values with no header row highlighting.
 
 ```yaml
 Type: SwitchParameter
@@ -97,11 +101,10 @@ Accept wildcard characters: False
 
 ## NOTES
 Basically stolen verbatim from thomykay's PoshConfluence SOAP API module.
-See link below.
+See links section.
 
 ## RELATED LINKS
 
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
 
-[https://github.com/thomykay/PoshConfluence](https://github.com/thomykay/PoshConfluence)
-
+[thomykay PoshConfluence](https://github.com/thomykay/PoshConfluence)

--- a/docs/en-US/Get-ChildPage.md
+++ b/docs/en-US/Get-ChildPage.md
@@ -8,52 +8,44 @@ schema: 2.0.0
 # Get-ChildPage
 
 ## SYNOPSIS
-List all child pages of a specific wiki page.
+Retrieve the child pages of a given wiki page or pages.
 
 ## SYNTAX
 
 ```powershell
-Get-ChildPage -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32> [-Recurse] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluenceChildPage -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32> [-Recurse] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION
-Get all pages that are descendants of a given page.
+Return all pages directly below the given page(s). Optionally,
+the -Recurse parameter will return all child pages, no matter how nested.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-ChildPage -ParentID 1234 | Select-Object ID, Title | Sort-Object Title
+Get-ConfluenceChildPage -PageID 123456
+Get-ConfluencePage -PageID 123456 | Get-ConfluenceChildPage
 ```
 
 Description
 
 -----------
 
-For the wiki page with ID 1234, get all pages immediately beneath it.
-Returns only each page's ID and Title, sorting results alphabetically by Title.
+Two different methods to return all pages directly below page 123456.
+Both examples should return identical results.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Page -Title 'Genghis Khan' | Get-ChildPage | Select -First 500
+Get-ConfluenceChildPage -PageID 123456 -Recurse
 ```
 
 Description
 
 -----------
 
-Find the Genghis Khan wiki page and pipe the results.
-Get only the first 500 children beneath that page.
-
-### -------------------------- EXAMPLE 3 --------------------------
-```powershell
-Get-ChildPage -ParentID 9999 -Recurse
-```
-
-Description
-
------------
-Fetch all child pages of page 9999 recursively.
+Instead of returning only 123456's child pages,
+return grandchildren, great-grandchildren, and so on.
 
 ## PARAMETERS
 
@@ -137,6 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeTotalCount
+NOTE: Not yet implemented.
 Causes an extra output of the total count at the beginning.
 Note this is actually a uInt64, but with a custom string representation.
 
@@ -169,8 +162,8 @@ Accept wildcard characters: False
 ```
 
 ### -First
+NOTE: Not yet implemented.
 Indicates how many items to return.
-Currently not supported.
 
 ```yaml
 Type: UInt64
@@ -191,10 +184,9 @@ Accept wildcard characters: False
 ### ConfluencePS.Page
 
 ## NOTES
+Confluence uses hierarchy to help organize content.
+This command is meant to help provide the intended context from the command line.
 
 ## RELATED LINKS
 
-[Get-Page]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Get-Label.md
+++ b/docs/en-US/Get-Label.md
@@ -8,35 +8,33 @@ schema: 2.0.0
 # Get-Label
 
 ## SYNOPSIS
-Returns a list of labels.
+Retrieve all labels applied to the given object(s).
 
 ## SYNTAX
 
 ```powershell
-Get-Label -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>]
+Get-ConfluenceLabel -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>]
  [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION
-Get all labels applied to a specific content.
+Currently, this command only returns a label list from wiki pages.
+It is intended to eventually support other content types as well.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Label -PageID 123456 -PageSize 500 -ApiURi "https://myserver.com/wiki" -Credential $cred
+Get-ConfluenceLabel -PageID 123456
 ```
-Lists the labels applied to page 123456.
-This also increases the size of results per page from 25 to 500.
+Returns all labels applied to wiki page 123456.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Page -SpaceKey NASA | Get-Label -Verbose
+Get-ConfluencePage -SpaceKey HOTH -Label skywalker | Get-ConfluenceLabel
 ```
-Get all pages that exist in NASA space (literally?).
-Search all of those pages (PageID will be provided over the pipe) for all of
-their active labels.
-Verbose flag would be good here to keep track of the request.
+For all pages in HOTH with the "skywalker" label applied,
+return the full list of labels found on each page.
 
 ## PARAMETERS
 
@@ -106,6 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeTotalCount
+NOTE: Not yet implemented.
 Causes an extra output of the total count at the beginning.
 Note this is actually a uInt64, but with a custom string representation.
 
@@ -138,8 +137,8 @@ Accept wildcard characters: False
 ```
 
 ### -First
+NOTE: Not yet implemented.
 Indicates how many items to return.
-Currently not supported.
 
 ```yaml
 Type: UInt64
@@ -163,10 +162,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Add-Label]()
-[Get-Page]()
-[Remove-Label]()
-[Set-Page]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Get-Page.md
+++ b/docs/en-US/Get-Page.md
@@ -17,11 +17,6 @@ Retrieve a listing of pages in your Confluence instance.
 Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
-### byTitle
-```powershell
-Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Title <String> [-SpaceKey <String>] [-Space <Space>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
-```
-
 ### byLabel
 ```powershell
 Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
@@ -29,12 +24,12 @@ Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-SpaceKey <String>]
 
 ### bySpace
 ```powershell
-Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -SpaceKey <String> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -SpaceKey <String> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ### bySpaceObject
 ```powershell
-Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Space <Space> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Space <Space> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION
@@ -148,14 +143,14 @@ Wildcards (*) are applied to each end to support partial matching.
 
 ```yaml
 Type: String
-Parameter Sets: byTitle
+Parameter Sets: bySpace, bySpaceObject
 Aliases: Name
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -SpaceKey
@@ -163,10 +158,10 @@ Filter results by space key (case-insensitive).
 
 ```yaml
 Type: String
-Parameter Sets: byTitle, byLabel
+Parameter Sets: bySpaceObject, byLabel
 Aliases: Key
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -190,10 +185,10 @@ Filter results by space object(s), typically from the pipeline.
 
 ```yaml
 Type: Space
-Parameter Sets: byTitle, byLabel
+Parameter Sets: bySpaceObject, byLabel
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)

--- a/docs/en-US/Get-Page.md
+++ b/docs/en-US/Get-Page.md
@@ -139,7 +139,7 @@ Accept wildcard characters: False
 
 ### -Title
 Filter results by page name (case-insensitive).
-Wildcards (*) are applied to each end to support partial matching.
+This supports wildcards (*) to allow for partial matching.
 
 ```yaml
 Type: String

--- a/docs/en-US/Get-Page.md
+++ b/docs/en-US/Get-Page.md
@@ -14,102 +14,83 @@ Retrieve a listing of pages in your Confluence instance.
 
 ### byId (Default)
 ```powershell
-Get-Page -ApiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ### byTitle
 ```powershell
-Get-Page -ApiURi <Uri> -Credential <PSCredential> -Title <String> [-SpaceKey <String>] [-Space <Space>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Title <String> [-SpaceKey <String>] [-Space <Space>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ### byLabel
 ```powershell
-Get-Page -ApiURi <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ### bySpace
 ```powershell
-Get-Page -ApiURi <Uri> -Credential <PSCredential> -SpaceKey <String> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -SpaceKey <String> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ### bySpaceObject
 ```powershell
-Get-Page -ApiURi <Uri> -Credential <PSCredential> -Space <Space> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Space <Space> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION
-Fetch Confluence pages, optionally filtering by Name/Space/ID.
+Return Confluence pages, filtered by ID, Name, or Space.
 Piped output into other cmdlets is generally tested and supported.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Page -ApiURi "https://myserver.com/wiki" -Credential $cred | Select-Object ID, Title -first 500 | Sort-Object Title
+Get-ConfluencePage -SpaceKey HOTH
+Get-ConfluenceSpace -SpaceKey HOTH | Get-ConfluencePage
 ```
 
 Description
 
 -----------
 
-List the first 500 pages found in your Confluence instance.
-Returns only each page's ID and Title, sorting results alphabetically by Title.
+Two different methods to return all wiki pages in space "HOTH".
+Both examples should return identical results.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Page -Title Confluence -SpaceKey "ABC" -PageSize 100
+Get-ConfluencePage -PageID 123456 | Format-List *
 ```
 
 Description
 
 -----------
 
-Get all pages with the word Confluence in the title in the 'ABC' sapce.
-Each call to the server is limited to 100 pages.
+Returns the wiki page with ID 123456.
+`Format-List *` displays all of the object's properties, including the full page body.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```powershell
-Get-ConfluenceSpace -Name Demo | Get-Page
+Get-ConfluencePage -Title 'luke*' -SpaceKey HOTH
 ```
 
 Description
 
 -----------
 
-Get all spaces with a name like *demo*, and then list pages from each returned space.
+Return all pages in HOTH whose names start with "luke" (case-insensitive).
+Wildcards (*) can be inserted to support partial matching.
 
 ### -------------------------- EXAMPLE 4 --------------------------
 ```powershell
-$FinalCountdown = Get-Page -PageID 54321
+Get-ConfluencePage -Label 'skywalker'
 ```
 
 Description
 
 -----------
 
-Store the page's ID, Title, Space Key, Version, and Body for use later in your script.
-
-### -------------------------- EXAMPLE 5 --------------------------
-```powershell
-$WhereIsShe = Get-Page -Title 'Rachel'
-```
-
-Description
-
------------
-
-Search for Rachel in order to find the correct page ID(s).
-
-### -------------------------- EXAMPLE 6 --------------------------
-```powershell
-$meetingPages = Get-Page -Label "meeting-notes" -SpaceKey PROJ1
-```
-
-Description
-
------------
-
-Captures all the meeting note pages in the Proj1 Space.
+Return all pages containing the label "skywalker" (case-insensitive).
+Label text must match exactly; no wildcards are applied.
 
 ## PARAMETERS
 
@@ -162,7 +143,8 @@ Accept wildcard characters: False
 ```
 
 ### -Title
-Filter results by name. This can contain wildcard and is case insensitive.
+Filter results by page name (case-insensitive).
+Wildcards (*) are applied to each end to support partial matching.
 
 ```yaml
 Type: String
@@ -177,8 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -SpaceKey
-Filter results by space key.
-Currently, this parameter is case sensitive.
+Filter results by space key (case-insensitive).
 
 ```yaml
 Type: String
@@ -205,7 +186,7 @@ Accept wildcard characters: False
 ```
 
 ### -Space
-Filter results by space object(s), typically from the pipeline
+Filter results by space object(s), typically from the pipeline.
 
 ```yaml
 Type: Space
@@ -227,12 +208,12 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Label
-Label(s) to use as search criteria to find pages
+Filter results to only pages with the specified label(s).
 
 ```yaml
 Type: String[]
@@ -264,6 +245,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeTotalCount
+NOTE: Not yet implemented.
 Causes an extra output of the total count at the beginning.
 Note this is actually a uInt64, but with a custom string representation.
 
@@ -296,9 +278,8 @@ Accept wildcard characters: False
 ```
 
 ### -First
-Currently not supported.
+NOTE: Not yet implemented.
 Indicates how many items to return.
-Defaults to 100.
 
 ```yaml
 Type: UInt64
@@ -322,9 +303,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[New-Page]()
-[Remove-Page]()
-[Set-Page]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Get-Space.md
+++ b/docs/en-US/Get-Space.md
@@ -4,6 +4,7 @@ online version: https://github.com/AtlassianPS/ConfluencePS/blob/master/docs/en-
 locale: en-US
 schema: 2.0.0
 ---
+
 # Get-Space
 
 ## SYNOPSIS
@@ -12,19 +13,18 @@ Retrieve a listing of spaces in your Confluence instance.
 ## SYNTAX
 
 ```powershell
-Get-Space -apiURi <Uri> -Credential <PSCredential> [[-SpaceKey] <String[]>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluenceSpace -apiURi <Uri> -Credential <PSCredential> [[-SpaceKey] <String[]>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION
-Fetch all Confluence spaces, optionally filtering by Name/Key/ID.
-Input for all parameters is not case sensitive.
+Return all Confluence spaces, optionally filtering by Key.
 Piped output into other cmdlets is generally tested and supported.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Space -ApiURi "https://myserver.com/wiki" -Credential $cred
+Get-ConfluenceSpace
 ```
 
 Description
@@ -35,14 +35,28 @@ Display the info of all spaces on the server.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Space -SpaceKey NASA
+Get-ConfluenceSpace -SpaceKey HOTH | Format-List *
 ```
 
 Description
 
 -----------
 
-Display the info of the space with key "NASA".
+Return only the space with key "HOTH" (case-insensitive).
+`Format-List *` displays all of the object's properties.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```powershell
+Get-ConfluenceSpace -ApiURi "https://myserver.com/wiki" -Credential $cred
+```
+
+Description
+
+-----------
+
+Manually specifying a server and authentication credentials, list all
+spaces found on the instance. `Set-ConfluenceInfo` usually makes this
+unnecessary, unless you are actively maintaining multiple instances.
 
 ## PARAMETERS
 
@@ -112,6 +126,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeTotalCount
+NOTE: Not yet implemented.
 Causes an extra output of the total count at the beginning.
 Note this is actually a uInt64, but with a custom string representation.
 
@@ -128,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -Skip
-Controls how many things will be skipped before starting output.
+Controls how many objects will be skipped before starting output.
 Defaults to 0.
 
 ```yaml
@@ -144,7 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -First
-Currently not supported.
+NOTE: Not yet implemented.
 Indicates how many items to return.
 
 ```yaml
@@ -169,8 +184,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[New-Space]()
-[Remove-Space]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/New-Page.md
+++ b/docs/en-US/New-Page.md
@@ -90,7 +90,7 @@ The wiki page will contain the text "Testing 123".
 -Convert will condition the -Body parameter's string into storage format.
 
 
-### -------------------------- EXAMPLE 5 --------------------------
+### -------------------------- EXAMPLE 6 --------------------------
 ```powershell
 $pageObject = [ConfluencePS.Page]@{
     Title = "My Title"

--- a/docs/en-US/New-Page.md
+++ b/docs/en-US/New-Page.md
@@ -14,54 +14,80 @@ Create a new page on your Confluence instance.
 
 ### byParameters (Default)
 ```powershell
-New-Page -apiURi <Uri> -Credential <PSCredential> -Title <String> [-ParentID <Int32>] [-Parent <Page>] [-SpaceKey <String>] [-Space <Space>] [-Body <String>] [-Convert] [-WhatIf] [-Confirm]
+New-ConfluencePage -apiURi <Uri> -Credential <PSCredential> -Title <String> [-ParentID <Int32>] [-Parent <Page>] [-SpaceKey <String>] [-Space <Space>] [-Body <String>] [-Convert] [-WhatIf] [-Confirm]
 ```
 
 ### byObject
 ```powershell
-New-Page -apiURi <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
+New-ConfluencePage -apiURi <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
 Create a new page on Confluence.
+
 Optionally include content in -Body.
-Content needs to be in "Confluence storage format;" see also -Convert.
+Body content needs to be in "Confluence storage format" -- see also -Convert.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-New-Page -Title 'Test New Page' -ParentID 123456 -Body 'Hello world' -Convert -WhatIf
+New-ConfluencePage -Title 'Test New Page' -SpaceKey asdf
 ```
 
 Description
 
 -----------
 
-Creates a new page as a child member of existing page 123456 with one line of page text.
-The Body defined is converted to Storage format by the "-Convert" parameter
+Create a new blank wiki page at the root of space "asdf".
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-New-Page -Title "Luke Skywalker" -Parent (Get-Page -title "Darth Vader" -SpaceKey "STARWARS")
+New-ConfluencePage -Title 'Luke Skywalker' -Parent (Get-ConfluencePage -Title 'Darth Vader' -SpaceKey 'STARWARS')
 ```
 
 Description
 
 -----------
 
-Creates a new page with an empty body as a child page of the "Darth Vader" page in Space "STARWARS".
+Creates a new blank wiki page as a child page below "Darth Vader" in the specified space.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```powershell
-[ConfluencePS.Page]@{Title="My Title";Space=[ConfluencePS.Space]@{Key="ABC"}} | New-Page -ApiURi "https://myserver.com/wiki" -Credential $cred
+New-ConfluencePage -Title 'Luke Skywalker' -ParentID 123456 -Verbose
 ```
 
 Description
 
 -----------
 
-Creates a new page "My Title" in the space "ABC" with an empty body.
+Creates a new blank wiki page as a child page below the wiki page with ID 123456.
+-Verbose provides extra technical details, if interested.
+
+### -------------------------- EXAMPLE 4 --------------------------
+```powershell
+New-ConfluencePage -Title 'foo' -SpaceKey 'bar' -Body $PageContents
+```
+
+Description
+
+-----------
+
+Create a new wiki page named 'foo' at the root of space 'bar'.
+The wiki page will contain the data stored in $PageContents.
+
+### -------------------------- EXAMPLE 5 --------------------------
+```powershell
+New-ConfluencePage -Title 'foo' -SpaceKey 'bar' -Body 'Testing 123' -Convert
+```
+
+Description
+
+-----------
+
+Create a new wiki page named 'foo' at the root of space 'bar'.
+The wiki page will contain the text "Testing 123".
+-Convert will condition the -Body parameter's string into storage format.
 
 ## PARAMETERS
 
@@ -98,7 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-A Page Object from which to create a new page.
+A ConfluencePS.Page object from which to create a new page.
 
 ```yaml
 Type: Page
@@ -144,7 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### -Parent
-Parent page as Page Object.
+Supply a ConfluencePS.Page object to use as the parent page.
 
 ```yaml
 Type: Page
@@ -160,7 +186,7 @@ Accept wildcard characters: False
 
 ### -SpaceKey
 Key of the space where the new page should exist.
-Only needed if you don't utilize ParentID.
+Only needed if you don't specify a parent page.
 
 ```yaml
 Type: String
@@ -176,6 +202,7 @@ Accept wildcard characters: False
 
 ### -Space
 Space Object in which to create the new page.
+Only needed if you don't specify a parent page.
 
 ```yaml
 Type: Space
@@ -205,8 +232,7 @@ Accept wildcard characters: False
 ```
 
 ### -Convert
-Convert the provided body to Confluence's storage format.
-Optional flag.
+Optionally, convert the provided body to Confluence's storage format.
 Has the same effect as calling ConvertTo-ConfluenceStorageFormat against your Body.
 
 ```yaml
@@ -262,11 +288,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Page]()
-[Remove-Page]()
-[Set-Page]()
-
-[ConvertTo-ConfluenceStorageFormat]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/New-Page.md
+++ b/docs/en-US/New-Page.md
@@ -89,6 +89,27 @@ Create a new wiki page named 'foo' at the root of space 'bar'.
 The wiki page will contain the text "Testing 123".
 -Convert will condition the -Body parameter's string into storage format.
 
+
+### -------------------------- EXAMPLE 5 --------------------------
+```powershell
+$pageObject = [ConfluencePS.Page]@{
+    Title = "My Title"
+    Space = [ConfluencePS.Space]@{
+        Key="ABC"
+    }
+}
+
+New-ConfluencePage -InputObject $pageObject
+$pageObject | New-ConfluencePage
+```
+
+Description
+
+-----------
+
+Two different methods of creating a new page from an object `ConfluencePS.Page`.
+Both examples should return identical results.
+
 ## PARAMETERS
 
 ### -apiURi

--- a/docs/en-US/New-Space.md
+++ b/docs/en-US/New-Space.md
@@ -40,6 +40,26 @@ Description
 
 Create a new blank space with an optional description and verbose output.
 
+
+### -------------------------- EXAMPLE 1 --------------------------
+```powershell
+$spaceObject = [ConfluencePS.Space]@{
+    Key         = "HOTH"
+    Name        = "Planet Hoth"
+    Description = "It's really cold"
+}
+
+New-ConfluenceSpace -InputObject $spaceObject
+$spaceObject | New-ConfluenceSpace
+```
+
+Description
+
+-----------
+
+Two different methods of creating a new space from an object `ConfluencePS.Space`.
+Both examples should return identical results.
+
 ## PARAMETERS
 
 ### -apiURi

--- a/docs/en-US/New-Space.md
+++ b/docs/en-US/New-Space.md
@@ -14,12 +14,12 @@ Create a new blank space on your Confluence instance.
 
 ### byObject (Default)
 ```powershell
-New-Space -apiURi <Uri> -Credential <PSCredential> -InputObject <Space> [-WhatIf] [-Confirm]
+New-ConfluenceSpace -apiURi <Uri> -Credential <PSCredential> -InputObject <Space> [-WhatIf] [-Confirm]
 ```
 
 ### byProperties
 ```powershell
-New-Space -apiURi <Uri> -Credential <PSCredential> -SpaceKey <String> -Name <String>
+New-ConfluenceSpace -apiURi <Uri> -Credential <PSCredential> -SpaceKey <String> -Name <String>
  [-Description <String>] [-WhatIf] [-Confirm]
 ```
 
@@ -31,25 +31,14 @@ Key and Name mandatory, Description recommended.
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-[ConfluencePS.Space]@{key="TEST";Name="Test Space"} | New-Space -ApiURi "https://myserver.com/wiki" -Credential $cred
+New-ConfluenceSpace -Key 'HOTH' -Name 'Planet Hoth' -Description "It's really cold" -Verbose
 ```
 
 Description
 
 -----------
 
-Create the new blank space.
-
-### -------------------------- EXAMPLE 2 --------------------------
-```powershell
-New-Space -Key 'TEST' -Name 'Test Space' -Description 'New blank space via REST API' -Verbose
-```
-
-Description
-
------------
-
-Create the new blank space with the optional description and verbose output.
+Create a new blank space with an optional description and verbose output.
 
 ## PARAMETERS
 
@@ -186,8 +175,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Space]()
-[Remove-Space]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/New-Space.md
+++ b/docs/en-US/New-Space.md
@@ -41,7 +41,7 @@ Description
 Create a new blank space with an optional description and verbose output.
 
 
-### -------------------------- EXAMPLE 1 --------------------------
+### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
 $spaceObject = [ConfluencePS.Space]@{
     Key         = "HOTH"

--- a/docs/en-US/Remove-Label.md
+++ b/docs/en-US/Remove-Label.md
@@ -13,49 +13,50 @@ Remove a label from existing Confluence content.
 ## SYNTAX
 
 ```powershell
-Remove-Label -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-Label <String[]>] [-WhatIf] [-Confirm]
+Remove-ConfluenceLabel -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-Label <String[]>] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
 Remove labels from Confluence content.
 Does accept multiple pages piped via Get-ConfluencePage.
-Specifically tested against pages, but should work against all content IDs.
+Untested against non-page content.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Remove-Label -ApiURi "https://myserver.com/wiki" -Credential $cred -Label seven -PageID 123456 -Verbose -Confirm
+Remove-ConfluenceLabel -PageID 123456 -Label 'seven' -Verbose -Confirm
 ```
 
 Description
 
 -----------
 
-Would remove label "seven" from the page with ID 123456.
-Verbose and Confirm flags both active.
+Remove label "seven" from the wiki page with ID 123456.
+Verbose and Confirm flags both active; you will be prompted before deletion.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-ConfluencePage -SpaceKey "ABC" | Remove-Label -Label asdf -WhatIf
+Get-ConfluencePage -SpaceKey 'ABC' -Label 'asdf' | Remove-ConfluenceLabel -Label 'asdf' -WhatIf
 ```
 
 Description
 
 -----------
 
-Would remove the label "asdf" from all pages in the ABC space.
+For all wiki pages in the ABC space, the label "asdf" would be removed.
+WhatIf parameter prevents any modifications.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```powershell
-(Get-ConfluenceSpace "ABC").Homepage | Remove-Label
+Get-ConfluenceChildPage -PageID 123456 | Remove-ConfluenceLabel
 ```
 
 Description
 
 -----------
 
-Removes all labels from the homepage of the ABC space.
+For all wiki pages immediately below page 123456, remove all labels from each page.
 
 ## PARAMETERS
 
@@ -163,9 +164,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Add-Label]()
-[Get-Label]()
-[Set-Label]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Remove-Page.md
+++ b/docs/en-US/Remove-Page.md
@@ -13,38 +13,50 @@ Trash an existing Confluence page.
 ## SYNTAX
 
 ```powershell
-Remove-Page -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-WhatIf] [-Confirm]
+Remove-ConfluencePage -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
 Delete existing Confluence content by page ID.
 This trashes most content, but will permanently delete "un-trashable" content.
-Untested against non-page content, but probably works anyway.
+Untested against non-page content.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Page -Title Oscar | Remove-Page -Confirm
+Remove-ConfluencePage -PageID 123456 -Verbose -Confirm
 ```
 
 Description
 
 -----------
 
-Send Oscar to the trash.
-Each matching page will ask you to confirm the deletion.
+Trash the wiki page with ID 123456.
+Verbose and Confirm flags both active; you will be prompted before removal.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Remove-Page -ApiURi "https://myserver.com/wiki" -Credential $cred -PageID 12345,12346 -Verbose -WhatIf
+Get-ConfluencePage -SpaceKey ABC -Title '*test*' | Remove-ConfluencePage -WhatIf
 ```
 
 Description
 
 -----------
 
-Simulates the removal of two specific pages.
+For all wiki pages in space ABC with "test" somewhere in the name,
+simulate the each page being trashed. -WhatIf prevents any removals.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```powershell
+Get-ConfluencePage -Label 'deleteme' | Remove-ConfluencePage
+```
+
+Description
+
+-----------
+
+For all wiki pages with the label "deleteme" applied, trash each page.
 
 ## PARAMETERS
 
@@ -137,9 +149,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Page]()
-[New-Page]()
-[Set-Page]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Remove-Space.md
+++ b/docs/en-US/Remove-Space.md
@@ -13,7 +13,7 @@ Remove an existing Confluence space.
 ## SYNTAX
 
 ```powershell
-Remove-Space -apiURi <Uri> -Credential <PSCredential> [-SpaceKey] <String[]> [-Force] [-WhatIf] [-Confirm]
+Remove-ConfluenceSpace -apiURi <Uri> -Credential <PSCredential> [-SpaceKey] <String[]> [-Force] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
@@ -24,27 +24,28 @@ Delete an existing Confluence space, including child content.
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Remove-Space -ApiURi "https://myserver.com/wiki" -Credential $cred -Key ABC,XYZ -Confirm
+Remove-ConfluenceSpace -SpaceKey ABC -WhatIf
 ```
 
 Description
 
 -----------
 
-Delete the space with key ABC and with key XYZ (note that key != name).
-Confirm will prompt before deletion.
+Simulates the deletion of wiki space ABC and all child content.
+-WhatIf parameter prevents removal of content.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Space | Where {$_.Name -like "*old"} | Remove-Space -Verbose -WhatIf
+Remove-ConfluenceSpace -SpaceKey XYZ -Force
 ```
 
 Description
 
 -----------
 
-Get all spaces ending in 'old' and simulate the deletion of them.
-Would simulate the removal of each space one by one with verbose output; -WhatIf flag active.
+Delete wiki space XYZ and all child content below it.
+By default, you will be prompted to confirm removal. ("Are you sure? Y/N")
+-Force suppresses all confirmation prompts and carries out the deletion.
 
 ## PARAMETERS
 
@@ -152,8 +153,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Space]()
-[New-Space]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Set-Info.md
+++ b/docs/en-US/Set-Info.md
@@ -8,42 +8,62 @@ schema: 2.0.0
 # Set-Info
 
 ## SYNOPSIS
-Gather URI/auth info for use in this session's REST API requests.
+Specify wiki location and authorization for use in this session's REST API requests.
 
 ## SYNTAX
 
 ```powershell
-Set-Info [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [[-PageSize] <Int32>] [-PromptCredentials]
+Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [[-PageSize] <Int32>] [-PromptCredentials]
 ```
 
 ## DESCRIPTION
+Set-ConfluenceInfo uses scoped variables and PSDefaultParameterValues to supply
+URI/auth info to all other functions in the module (e.g. Get-ConfluenceSpace).
+These session defaults can be overwritten on any single command, but using
+Set-ConfluenceInfo avoids repetitively specifying -ApiUri and -Credential parameters.
+
+Confluence's REST API supports passing basic authentication in headers.
+(If you have a better suggestion for how to handle auth, please reach out on GitHub!)
+
 Unless allowing anonymous access to your instance, credentials are needed.
-Confluence REST API supports passing basic authentication in headers.
-(If you have a better suggestion for how to handle this, please reach out on GitHub!)
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Set-Info -BaseURI 'https://brianbunke.atlassian.net/wiki' -PromptCredentials
+Set-ConfluenceInfo -BaseURI 'https://yournamehere.atlassian.net/wiki' -PromptCredentials
 ```
 
 Description
 
 -----------
 
-Declare your base install; be prompted for username and password.
+Declare the URI of your Confluence instance; be prompted for username and password.
+Note that Atlassian Cloud Confluence instances typically use the /wiki subdirectory.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Set-Info -BaseURI $ConfluenceURL -Credential $MyCreds -PageSize 100
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com'
 ```
 
 Description
 
 -----------
 
-Sets the url, credentials and default page size for the session.
+Declare the URI of your Confluence instance. You will not be prompted for credentials,
+and other commands would attempt to connect anonymously with read-only permissions.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```powershell
+Set-ConfluenceInfo -BaseURI 'https://wiki.contoso.com' -PromptCredentials -PageSize 50
+```
+
+Description
+
+-----------
+
+Declare the URI of your Confluence instance; be prompted for username and password.
+Set the default "page size" for all your commands in this session to 50 (see Notes).
 
 ## PARAMETERS
 
@@ -80,6 +100,7 @@ Accept wildcard characters: False
 
 ### -PageSize
 Default PageSize for the invocations.
+More info in the Notes field of this help file.
 
 ```yaml
 Type: Int32
@@ -114,6 +135,16 @@ Accept wildcard characters: False
 
 ## NOTES
 
+The default page size for all commands is 25.
+Using the -PageSize parameter changes the default for all commands in your current session.
+
+Tweaking PageSize can help improve pipeline performance when returning many objects.
+See related links for implementation discussion and details.
+
+(If you don't know exactly what this means, feel free to ignore it.)
+
 ## RELATED LINKS
 
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
+[https://github.com/AtlassianPS/ConfluencePS/issues/50](https://github.com/AtlassianPS/ConfluencePS/issues/50)
+[https://github.com/AtlassianPS/ConfluencePS/pull/59](https://github.com/AtlassianPS/ConfluencePS/pull/59)

--- a/docs/en-US/Set-Info.md
+++ b/docs/en-US/Set-Info.md
@@ -65,6 +65,20 @@ Description
 Declare the URI of your Confluence instance; be prompted for username and password.
 Set the default "page size" for all your commands in this session to 50 (see Notes).
 
+
+### -------------------------- EXAMPLE 4 --------------------------
+```powershell
+$Cred = Get-Credential
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -Credential $Cred
+```
+
+Description
+
+-----------
+
+Declare the URI of your Confluence instance and the credentials (username and
+password).
+
 ## PARAMETERS
 
 ### -BaseURi

--- a/docs/en-US/Set-Label.md
+++ b/docs/en-US/Set-Label.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-Label
 
 ## SYNOPSIS
-Set the label for an existing Confluence content.
+Set the labels applied to existing Confluence content.
 
 ## SYNTAX
 
@@ -17,33 +17,34 @@ Set-Label -apiURi <Uri> -Credential <PSCredential> [-PageID] <Int32[]> -Label <S
 ```
 
 ## DESCRIPTION
-Sets the label for Confluence content.
-All preexisting labels will be removed in the process.
+Sets desired labels for Confluence content.
+(Currently, Set-ConfluenceLabel only supports interacting with wiki pages.)
+All preexisting labels will be *removed* in the process.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Set-Label -ApiURi "https://myserver.com/wiki" -Credential $cred -Label seven -PageID 123456 -Verbose -Confirm
+Set-ConfluenceLabel -PageID 123456 -Label 'a','b','c'
 ```
 
 Description
 
 -----------
 
-Would remove any label previously assigned to the page with ID 123456 and would add the label "seven"
-Verbose and Confirm flags both active.
+For existing wiki page with ID 123456, remove all labels, then add the three specified.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-ConfluencePage -SpaceKey "ABC" | Set-Label -Label "asdf","qwer" -WhatIf
+Get-ConfluencePage -SpaceKey 'ABC' | Set-Label -Label '123' -WhatIf
 ```
 
 Description
 
 -----------
 
-Would remove all labels and adds "asdf" and "qwer" to all pages in the ABC space.
+Would remove all labels and apply only the label "123" to all pages in the ABC space.
+-WhatIf reports on simulated changes, but does not modifying anything.
 
 ## PARAMETERS
 
@@ -151,9 +152,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Add-Label]()
-[Get-Label]()
-[Remove-Label]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Set-Page.md
+++ b/docs/en-US/Set-Page.md
@@ -14,12 +14,12 @@ Edit an existing Confluence page.
 
 ### byParameters (Default)
 ```powershell
-Set-Page -apiURi <Uri> -Credential <PSCredential> -PageID <Int32> [-Title <String>] [-Body <String>] [-Convert] [-ParentID <Int32>] [-Parent <Page>] [-WhatIf] [-Confirm]
+Set-ConfluencePage -apiURi <Uri> -Credential <PSCredential> -PageID <Int32> [-Title <String>] [-Body <String>] [-Convert] [-ParentID <Int32>] [-Parent <Page>] [-WhatIf] [-Confirm]
 ```
 
 ### byObject
 ```powershell
-Set-Page -apiURi <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
+Set-ConfluencePage -apiURi <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
@@ -30,42 +30,39 @@ Content needs to be in "Confluence storage format." Use -Convert if not precondi
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```powershell
-Get-Page -Title 'My First Page' -Expand | Set-Page -Body 'Hello World!' -Convert
+Set-ConfluencePage -PageID 123456 -Title 'Counting'
 ```
 
 Description
 
 -----------
 
-Probably the easiest edit method, overwriting contents with a short sentence.
-Use Get-Page to pipe in PageID & CurrentVersion.
-(See "Get-Help Get-Page -Examples" for help)
--Convert molds the sentence into a format Confluence will accept.
+For existing wiki page 123456, change its name to "Counting".
 
 ### -------------------------- EXAMPLE 2 --------------------------
 ```powershell
-Get-Page -Title 'Lew Alcindor' -Limit 100 -Expand | Set-Page -Title 'Kareem Abdul-Jabbar' -Verbose
+Set-ConfluencePage -PageID 123456 -Body 'Hello World!' -Convert
 ```
 
 Description
 
 -----------
 
-Change the page's name.
-Body remains the same, via piping the existing contents.
-Verbose flag active for additional screen output.
+For existing wiki page 123456, update its page contents to "Hello World!"
+-Convert applies the "Confluence storage format" to your given string.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```powershell
-Get-Page -SpaceKey MATRIX | Set-Page -Body 'Agent Smith' -Convert -WhatIf
+Set-ConfluencePage -PageID 123456 -ParentID 654321
+Set-ConfluencePage -PageID 123456 -Parent (Get-ConfluencePage -PageID 654321)
 ```
 
 Description
 
 -----------
 
-Overwrites the contents of all pages in the MATRIX space.
-WhatIf flag tells you how many pages would have been affected.
+Two different methods to set a new parent page.
+Parent page 654321 will now have child page 123456.
 
 ## PARAMETERS
 
@@ -251,11 +248,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Get-Page]()
-[New-Page]()
-[Remove-Page]()
-
-[ConvertTo-ConfluenceStorageFormat]()
-
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
-

--- a/docs/en-US/Set-Page.md
+++ b/docs/en-US/Set-Page.md
@@ -64,6 +64,23 @@ Description
 Two different methods to set a new parent page.
 Parent page 654321 will now have child page 123456.
 
+
+### -------------------------- EXAMPLE 4 --------------------------
+```powershell
+$page = Get-ConfluencePage -PageID 123456
+$page.Title = "New Title"
+
+Set-ConfluencePage -InputObject $page
+$page | Set-ConfluencePage
+```
+
+Description
+
+-----------
+
+Two different methods to set a new parent page using a `ConfluencePS.Page`
+object.
+
 ## PARAMETERS
 
 ### -apiURi


### PR DESCRIPTION
### Description
Update the help files for all module functions.

### Motivation and Context
Helps #43 (prepare `2.0` release) by updating documentation.

### More info on PlatyPS
Some of these PlatyPS files render weirdly at the console.

```posh
Get-Help Get-ConfluenceSpace -Full
```

A list of things I noticed:

- Single line breaks are not observed; only doubles, when splitting paragraphs
- `EXAMPLES` crowd into each other
- `LINKS` hates the markdown, and instead lists each URI twice
- `SYNTAX` isn't displaying a prefixed command name for me

I decided to not waste time on those items; I want to ship `2.0`, and some help files looking weird but not losing functionality isn't blocking anything.

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
  - Forgive me...I snuck in a0db46b as I was testing & updating examples
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated 📜 

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.