### PR TITLE
Remove the necessity of casting to `string[]` in Add-Label

### DIFF
--- a/ConfluencePS/Public/Add-Label.ps1
+++ b/ConfluencePS/Public/Add-Label.ps1
@@ -52,6 +52,12 @@
             $Label = $Label.Labels
         }
 
+        # Test if Label is String[]
+        [String[]]$_label = $Label
+        $_label = $_label | Where-Object {$_ -ne "ConfluencePS.Label"}
+        if ($_label) {
+            [String[]]$Label = $_label
+        }
         # Allow only for Label to be a [String[]] or [ConfluencePS.Label[]]
         $allowedLabelTypes = @(
             "System.String"

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -437,7 +437,7 @@ InModuleScope ConfluencePS {
         # ARRANGE
         $SpaceKey = "PESTER"
         $Page1 = Get-ConfluencePage -Title "Pester New Page Piped" -SpaceKey $SpaceKey -ErrorAction Stop
-        $Label1 = [string[]]("pestera", "pesterb", "pesterc")
+        $Label1 = "pestera", "pesterb", "pesterc"
         $Label2 = "pesterall"
         $PartialLabel = "pest"
 


### PR DESCRIPTION
### Description
Add-Label currently casts `-Label` to `[Object[]]`
This makes calling the parameter with a string array very annoying

### Motivation and Context
closes #82 

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
