### PR TITLE
Improve Get-Page byTitle

### DIFF
--- a/ConfluencePS/Private/ConvertTo-Page.ps1
+++ b/ConfluencePS/Private/ConvertTo-Page.ps1
@@ -16,46 +16,50 @@ function ConvertTo-Page {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Page"
             [ConfluencePS.Page](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                id,
-                status,
-                title,
-                @{Name = "space"; Expression = {
-                        if ($_.space) {
-                            ConvertTo-Space $_.space
+                        id,
+                    status,
+                    title,
+                    @{Name = "space"; Expression = {
+                            if ($_.space) {
+                                ConvertTo-Space $_.space
+                            }
+                            else {$null}
                         }
-                        else {$null}
-                    }
-                },
-                @{Name = "version"; Expression = {
-                        if ($_.version) {
-                            ConvertTo-Version $_.version
+                    },
+                    @{Name = "version"; Expression = {
+                            if ($_.version) {
+                                ConvertTo-Version $_.version
+                            }
+                            else {$null}
                         }
-                        else {$null}
-                    }
-                },
-                @{Name = "body"; Expression = {$_.body.storage.value}},
-                @{Name = "ancestors"; Expression = {
-                        if ($_.ancestors) {
-                            ConvertTo-PageAncestor $_.ancestors
+                    },
+                    @{Name = "body"; Expression = {$_.body.storage.value}},
+                    @{Name = "ancestors"; Expression = {
+                            if ($_.ancestors) {
+                                ConvertTo-PageAncestor $_.ancestors
+                            }
+                            else {$null}
                         }
-                        else {$null}
-                    }
-                },
-                @{Name = "URL"; Expression = {
-                        if ($_._links.webui) {
-                            "{0}{1}" -f $_._links.base, $_._links.webui
+                    },
+                    @{Name = "URL"; Expression = {
+                            $base = $_._links.base
+                            if (!($base)) { $base = $_._links.self -replace '\/rest.*', '' }
+                            if ($_._links.webui) {
+                                "{0}{1}" -f $base, $_._links.webui
+                            }
+                            else {$null}
                         }
-                        else {$null}
-                    }
-                },
-                @{Name = "ShortURL"; Expression = {
-                        if ($_._links.tinyui) {
-                            "{0}{1}" -f $_._links.base, $_._links.tinyui
+                    },
+                    @{Name = "ShortURL"; Expression = {
+                            $base = $_._links.base
+                            if (!($base)) { $base = $_._links.self -replace '\/rest.*', '' }
+                            if ($_._links.tinyui) {
+                                "{0}{1}" -f $base, $_._links.tinyui
+                            }
+                            else {$null}
                         }
-                        else {$null}
                     }
-                }
-            ))
+                ))
         }
     }
 }

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -113,13 +113,9 @@ function Get-Page {
                 $iwParameters["Uri"] = $resourceApi -f ''
                 $iwParameters["GetParameters"]["type"] = "page"
                 if ($SpaceKey) { $iwParameters["GetParameters"]["spaceKey"] = $SpaceKey }
+                if ($Title) { $iwParameters["GetParameters"]["title"] = $Title }
 
-                if ($Title) {
-                    Invoke-Method @iwParameters | Where-Object {$_.Title -like "$Title"}
-                }
-                else {
-                    Invoke-Method @iwParameters
-                }
+                Invoke-Method @iwParameters
                 break
             }
             "byLabel" {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -113,9 +113,13 @@ function Get-Page {
                 $iwParameters["Uri"] = $resourceApi -f ''
                 $iwParameters["GetParameters"]["type"] = "page"
                 if ($SpaceKey) { $iwParameters["GetParameters"]["spaceKey"] = $SpaceKey }
-                if ($Title) { $iwParameters["GetParameters"]["title"] = $Title }
 
-                Invoke-Method @iwParameters
+                if ($Title) {
+                    Invoke-Method @iwParameters | Where-Object {$_.Title -like "$Title"}
+                }
+                else {
+                    Invoke-Method @iwParameters
+                }
                 break
             }
             "byLabel" {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -59,6 +59,13 @@ function Get-Page {
         )]
         [string[]]$Label,
 
+        [Parameter(
+            Position = 0,
+            Mandatory = $true,
+            ParameterSetName = "byQuery"
+        )]
+        [string]$Query,
+
         [ValidateRange(1, [int]::MaxValue)]
         [int]$PageSize = 25
     )
@@ -106,13 +113,9 @@ function Get-Page {
                 $iwParameters["Uri"] = $resourceApi -f ''
                 $iwParameters["GetParameters"]["type"] = "page"
                 if ($SpaceKey) { $iwParameters["GetParameters"]["spaceKey"] = $SpaceKey }
+                if ($Title) { $iwParameters["GetParameters"]["title"] = $Title }
 
-                if ($Title) {
-                    Invoke-Method @iwParameters | Where-Object {$_.Title -like "$Title"}
-                }
-                else {
-                    Invoke-Method @iwParameters
-                }
+                Invoke-Method @iwParameters
                 break
             }
             "byLabel" {
@@ -126,6 +129,14 @@ function Get-Page {
 
                 Invoke-Method @iwParameters
                 break
+            }
+            "byQuery" {
+                $iwParameters["Uri"] = $resourceApi -f "/search"
+
+                $cqlQuery = ConvertTo-URLEncoded $Query
+                $iwParameters["GetParameters"]["cql"] = "type=page AND $cqlQuery"
+
+                Invoke-Method @iwParameters
             }
         }
     }

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -329,7 +329,7 @@ InModuleScope ConfluencePS {
         Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
         # ACT
-        $GetTitle1   = Get-ConfluencePage -Title $Title1 -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
+        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
         $GetTitle2   = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetPartial  = Get-ConfluencePage -Title $Title4 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetWildcard = Get-ConfluencePage -Title $Title5 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
@@ -346,7 +346,7 @@ InModuleScope ConfluencePS {
             $GetTitle1.Count | Should Be 1
             $GetTitle2.Count | Should Be 1
             $GetPartial.Count | Should Be 0
-            $GetWildcard.Count | Should Be 0
+            $GetWildcard.Count | Should Be 1
             $GetID1.Count | Should Be 1
             $GetID2.Count | Should Be 1
             $GetKeys.Count | Should Be 5
@@ -426,8 +426,8 @@ InModuleScope ConfluencePS {
             $GetKeys.URL | Should BeOfType [String]
             $GetKeys.URL | Should Not BeNullOrEmpty
             $GetByLabel.URL | Should BeOfType [String]
-            $GetByLabel.URL | Should BeOfType [String]
-            $GetByQuery.URL | Should Not BeNullOrEmpty
+            $GetByLabel.URL | Should Not BeNullOrEmpty
+            $GetByQuery.URL | Should BeOfType [String]
             $GetByQuery.URL | Should Not BeNullOrEmpty
         }
         It 'shorturl is string' {
@@ -442,8 +442,8 @@ InModuleScope ConfluencePS {
             $GetKeys.ShortURL | Should BeOfType [String]
             $GetKeys.ShortURL | Should Not BeNullOrEmpty
             $GetByLabel.ShortURL | Should BeOfType [String]
-            $GetByLabel.ShortURL | Should BeOfType [String]
-            $GetByQuery.ShortURL | Should Not BeNullOrEmpty
+            $GetByLabel.ShortURL | Should Not BeNullOrEmpty
+            $GetByQuery.ShortURL | Should BeOfType [String]
             $GetByQuery.ShortURL | Should Not BeNullOrEmpty
         }
         It 'has a meaningful string value' {

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -323,12 +323,13 @@ InModuleScope ConfluencePS {
         $Title3 = "Pester Test Space Home"
         $Title4 = "orphan"
         $Title5 = "*orphan"
+        $Query = "space=PESTER and title~`"*Object`""
         $Content = "<p>Hi Pester!</p>"
         (Get-ConfluenceSpace -SpaceKey $SpaceKey).Homepage | Add-ConfluenceLabel -Label "important" -ErrorAction Stop
         Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
         # ACT
-        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
+        $GetTitle1   = Get-ConfluencePage -Title $Title1 -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
         $GetTitle2   = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetPartial  = Get-ConfluencePage -Title $Title4 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetWildcard = Get-ConfluencePage -Title $Title5 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
@@ -336,6 +337,7 @@ InModuleScope ConfluencePS {
         $GetID2 = Get-ConfluencePage -PageID $GetTitle2.ID -ErrorAction SilentlyContinue
         $GetKeys = Get-ConfluencePage -SpaceKey $SpaceKey | Sort ID -ErrorAction SilentlyContinue
         $GetByLabel = Get-ConfluencePage -Label "important" -ErrorAction SilentlyContinue
+        $GetByQuery = Get-ConfluencePage -Query $query -ErrorAction SilentlyContinue
         $GetSpacePage = Get-ConfluencePage -Space (Get-ConfluenceSpace -SpaceKey $SpaceKey) -ErrorAction SilentlyContinue
         $GetSpacePiped = Get-ConfluenceSpace -SpaceKey $SpaceKey | Get-ConfluencePage -ErrorAction SilentlyContinue
 
@@ -344,12 +346,13 @@ InModuleScope ConfluencePS {
             $GetTitle1.Count | Should Be 1
             $GetTitle2.Count | Should Be 1
             $GetPartial.Count | Should Be 0
-            $GetWildcard.Count | Should Be 1
+            $GetWildcard.Count | Should Be 0
             $GetID1.Count | Should Be 1
             $GetID2.Count | Should Be 1
             $GetKeys.Count | Should Be 5
             $GetByLabel.Count | Should Be 1
             $GetSpacePage.Count | Should Be 5
+            $GetByQuery.Count | Should Be 2
             $GetSpacePiped.Count | Should Be 5
         }
         It 'returns an object with specific properties' {
@@ -359,12 +362,14 @@ InModuleScope ConfluencePS {
             $GetID2 | Should BeOfType [ConfluencePS.Page]
             $GetKeys | Should BeOfType [ConfluencePS.Page]
             $GetByLabel | Should BeOfType [ConfluencePS.Page]
+            $GetByQuery | Should BeOfType [ConfluencePS.Page]
             ($GetTitle1 | Get-Member -MemberType Property).Count | Should Be 9
             ($GetTitle2 | Get-Member -MemberType Property).Count | Should Be 9
             ($GetID1 | Get-Member -MemberType Property).Count | Should Be 9
             ($GetID2 | Get-Member -MemberType Property).Count | Should Be 9
             ($GetKeys | Get-Member -MemberType Property).Count | Should Be 9
             ($GetByLabel | Get-Member -MemberType Property).Count | Should Be 9
+            ($GetByQuery | Get-Member -MemberType Property).Count | Should Be 9
         }
         It 'id is integer' {
             $GetTitle1.ID | Should BeOfType [Int]
@@ -373,6 +378,7 @@ InModuleScope ConfluencePS {
             $GetID2.ID | Should BeOfType [Int]
             $GetKeys.ID | Should BeOfType [Int]
             $GetByLabel.ID | Should BeOfType [Int]
+            $GetByQuery.ID | Should BeOfType [Int]
         }
         It 'id matches the specified value' {
             $GetID1.ID | Should Be $GetTitle1.ID
@@ -420,7 +426,9 @@ InModuleScope ConfluencePS {
             $GetKeys.URL | Should BeOfType [String]
             $GetKeys.URL | Should Not BeNullOrEmpty
             $GetByLabel.URL | Should BeOfType [String]
-            $GetByLabel.URL | Should Not BeNullOrEmpty
+            $GetByLabel.URL | Should BeOfType [String]
+            $GetByQuery.URL | Should Not BeNullOrEmpty
+            $GetByQuery.URL | Should Not BeNullOrEmpty
         }
         It 'shorturl is string' {
             $GetTitle1.ShortURL | Should BeOfType [String]
@@ -434,7 +442,9 @@ InModuleScope ConfluencePS {
             $GetKeys.ShortURL | Should BeOfType [String]
             $GetKeys.ShortURL | Should Not BeNullOrEmpty
             $GetByLabel.ShortURL | Should BeOfType [String]
-            $GetByLabel.ShortURL | Should Not BeNullOrEmpty
+            $GetByLabel.ShortURL | Should BeOfType [String]
+            $GetByQuery.ShortURL | Should Not BeNullOrEmpty
+            $GetByQuery.ShortURL | Should Not BeNullOrEmpty
         }
         It 'has a meaningful string value' {
             $GetTitle1.Version.ToString() | Should Be $GetTitle1.Version.Number.ToString()

--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -329,7 +329,7 @@ InModuleScope ConfluencePS {
         Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
         # ACT
-        $GetTitle1   = Get-ConfluencePage -Title $Title1.ToLower() -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
+        $GetTitle1   = Get-ConfluencePage -Title $Title1 -SpaceKey $SpaceKey -PageSize 200 -ErrorAction SilentlyContinue
         $GetTitle2   = Get-ConfluencePage -Title $Title2 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetPartial  = Get-ConfluencePage -Title $Title4 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
         $GetWildcard = Get-ConfluencePage -Title $Title5 -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
@@ -346,7 +346,7 @@ InModuleScope ConfluencePS {
             $GetTitle1.Count | Should Be 1
             $GetTitle2.Count | Should Be 1
             $GetPartial.Count | Should Be 0
-            $GetWildcard.Count | Should Be 1
+            $GetWildcard.Count | Should Be 0
             $GetID1.Count | Should Be 1
             $GetID2.Count | Should Be 1
             $GetKeys.Count | Should Be 5

--- a/docs/commands/Get-Page.md
+++ b/docs/commands/Get-Page.md
@@ -158,9 +158,7 @@ Accept wildcard characters: False
 
 ### -Title
 Filter results by page name (case-insensitive).
-
-This does not support wildcards (*).
-In order to use wildcards, use `-Query 'title~"*term*"'`.
+This supports wildcards (*) to allow for partial matching.
 
 ```yaml
 Type: String

--- a/docs/commands/Get-Page.md
+++ b/docs/commands/Get-Page.md
@@ -29,6 +29,11 @@ Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-SpaceKey <String>]
 Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -SpaceKey <String> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
 ```
 
+### byQuery
+```powershell
+Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> [-Query <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+```
+
 ### bySpaceObject
 ```powershell
 Get-ConfluencePage -ApiURi <Uri> -Credential <PSCredential> -Space <Space> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
@@ -89,6 +94,18 @@ Description
 Return all pages containing the label "skywalker" (case-insensitive).
 Label text must match exactly; no wildcards are applied.
 
+### -------------------------- EXAMPLE 5 --------------------------
+```powershell
+Get-ConfluencePage -Query "mention = jsmith and creator != jsmith"
+```
+
+Description
+
+-----------
+
+Return all pages matching the query.
+
+
 ## PARAMETERS
 
 ### -ApiURi
@@ -141,7 +158,9 @@ Accept wildcard characters: False
 
 ### -Title
 Filter results by page name (case-insensitive).
-This supports wildcards (*) to allow for partial matching.
+
+This does not support wildcards (*).
+In order to use wildcards, use `-Query 'title~"*term*"'`.
 
 ```yaml
 Type: String
@@ -219,6 +238,23 @@ Aliases:
 
 Required: True
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+Use Confluences advanced search: [CQL](https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/).
+
+This cmdlet will always append a filter to only look for pages (`type=page`).
+
+```yaml
+Type: String
+Parameter Sets: byQuery
+Aliases:
+
+Required: True
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/commands/Get-Page.md
+++ b/docs/commands/Get-Page.md
@@ -158,7 +158,9 @@ Accept wildcard characters: False
 
 ### -Title
 Filter results by page name (case-insensitive).
-This supports wildcards (*) to allow for partial matching.
+
+This does not support wildcards (*).
+In order to use wildcards, use `-Query 'title~"*term*"'`.
 
 ```yaml
 Type: String


### PR DESCRIPTION
### Description
* Improves the search when using `-Title`
  - this no longer takes wildcards
  - previously this command took ~ 3 minutes to complete on my prod system (over 1000 pages in the space)
  - now it takes less than 5 sec

### Motivation and Context
Improve the search for pages when using `-Title`.
The command had to get all the pages in a space and then filter.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
