### PR TITLE
Updated Contributing & Getting Started URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Get-Command -Module ConfluencePS
 Get-Help Get-ConfluencePage -Full   # or any other command
 ```
 
-For first steps to get up and running, check out the [Getting Started](https://atlassianps.org/docs/ConfluencePS/Getting_Started.html) page.
+For first steps to get up and running, check out the [Getting Started](https://atlassianps.org/docs/ConfluencePS/#getting-started) page.
 
 ### Contribute
 
 Want to contribute to AtlassianPS? Great!
 We appreciate [everyone](https://atlassianps.org/#people) who invests their time to make our modules the best they can be.
 
-Check out our guidelines on [Contributing](https://atlassianps.org/docs/Contributing.html) to our modules and documentation.
+Check out our guidelines on [Contributing](https://atlassianps.org/docs/Contributing/) to our modules and documentation.
 
 ## Acknowledgments
 


### PR DESCRIPTION
### Description
Amended the URLs of the Getting Started and Contributing URL's to point to the correct locations

### Motivation and Context
Directs users to the correct link as previous links were returning 404
No open issue for this but I wanted to start using the module so decided to fix the URLs for anyone else doing the same.

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
