### PR TITLE
Replace Convert::ToInt with explicite casting

### DIFF
--- a/ConfluencePS/ConfluencePS.Types.cs
+++ b/ConfluencePS/ConfluencePS.Types.cs
@@ -86,7 +86,7 @@ namespace ConfluencePS
 		public String Title { get; set; }
 		public String Filename { get; set; }
 		public String MediaType { get; set; }
-		public Int32 FileSize { get; set; }
+		public UInt64 FileSize { get; set; }
 		public String Comment { get; set; }
 		public String SpaceKey { get; set; }
 		public Int32 PageID { get; set; }

--- a/ConfluencePS/Private/ConvertTo-Attachment.ps1
+++ b/ConfluencePS/Private/ConvertTo-Attachment.ps1
@@ -20,14 +20,12 @@ function ConvertTo-Attachment {
                 $PageId = $_.container.id
             }
             else {
-                $PageID = $_._expandable.container -replace '^.*\/content\/', ''
-                $PageID = [convert]::ToInt32($PageID, 10)
+                [UInt32]$PageID = $_._expandable.container -replace '^.*\/content\/', ''
             }
 
             [ConfluencePS.Attachment](ConvertTo-Hashtable -InputObject ($object | Select-Object `
                     @{Name = "id"; Expression = {
-                            $ID = $_.id -replace 'att', ''
-                            [convert]::ToInt32($ID, 10)
+                            [UInt32]($_.id -replace 'att', '')
                         }
                     },
                     status,


### PR DESCRIPTION
### Description

Replaced incorrect usage of `[Convert]::ToInit()` with explicit casting to `[UInt32]`.

### Motivation and Context

closes #165

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
