### PR TITLE
Change FileName to FilePath, add Confluence prefix

### DIFF
--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Help tests" -Tag Documentation {
     )
 
     $module = Get-Module $env:BHProjectName
-    $commands = Get-Command -Module $module -CommandType Cmdlet, Function, Workflow  # Not alias
+    $commands = Get-Command -Module $module -CommandType Cmdlet, Function # Not alias
     # $classes = Get-ChildItem "$env:BHProjectPath/docs/en-US/classes/*"
     # $enums = Get-ChildItem "$env:BHProjectPath/docs/en-US/enumerations/*"
 

--- a/docs/en-US/commands/Set-Attachment.md
+++ b/docs/en-US/commands/Set-Attachment.md
@@ -16,7 +16,7 @@ Updates an existing attachment with a new file.
 ## SYNTAX
 
 ```powershell
-Set-Attachment -ApiUri <Uri> -Credential <PSCredential> [-Attachment] <Attachment> -FilePath <String> [-WhatIf] [-Confirm]
+Set-ConfluenceAttachment -ApiUri <Uri> -Credential <PSCredential> [-Attachment] <Attachment> -FilePath <String> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
@@ -29,7 +29,7 @@ Updates an existing attachment with a new file.
 
 ```powershell
 $attachment = Get-ConfluenceAttachment -PageID 123456 -FileNameFilter test.png
-Set-ConfluenceAttachment -Attachment $attachment -FileName newTest.png -Verbose -Confirm
+Set-ConfluenceAttachment -Attachment $attachment -FilePath newTest.png -Verbose -Confirm
 ```
 
 For the attachment test.png on page with ID 123456, replace the file with the file newTest.png.
@@ -37,7 +37,7 @@ For the attachment test.png on page with ID 123456, replace the file with the fi
 ### -------------------------- EXAMPLE 2 --------------------------
 
 ```powershell
-Get-ConfluenceAttachment -PageID 123456 -FileNameFilter test.png | Set-Attachment -FileName newTest.png -WhatIf
+Get-ConfluenceAttachment -PageID 123456 -FileNameFilter test.png | Set-ConfluenceAttachment -FilePath newTest.png -WhatIf
 ```
 
 Would replace the attachment test.png to the page with ID 123456.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
Fixes for small mistakes in Documentation
### Description

Fixes for small mistakes in Documentation for function Set-Attachment

### Motivation and Context

When I tryed use cmdlet Set-ConfluenceAttachment by Docs I had some error.
So I fixed it.
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
