### PR TITLE
Exclude page body from Get-Page and Get-ChildPage calls

### DIFF
--- a/ConfluencePS/Public/Get-ChildPage.ps1
+++ b/ConfluencePS/Public/Get-ChildPage.ps1
@@ -26,7 +26,9 @@ function Get-ChildPage {
         [switch]$Recurse,
 
         [ValidateRange(1, [int]::MaxValue)]
-        [int]$PageSize = 25
+        [int]$PageSize = 25,
+
+        [switch]$ExcludePageBody
     )
 
     BEGIN {
@@ -59,6 +61,10 @@ function Get-ChildPage {
             expand = "space,version,body.storage,ancestors"
             limit  = $PageSize
         }
+        if($ExcludePageBody.IsPresent){
+            $iwParameters.GetParameters.expand = "space,version,ancestors"
+        }
+
         $iwParameters['OutputType'] = [ConfluencePS.Page]
 
         # Paging

--- a/ConfluencePS/Public/Get-ChildPage.ps1
+++ b/ConfluencePS/Public/Get-ChildPage.ps1
@@ -61,7 +61,7 @@ function Get-ChildPage {
             expand = "space,version,body.storage,ancestors"
             limit  = $PageSize
         }
-        if($ExcludePageBody.IsPresent){
+        if($ExcludePageBody){
             $iwParameters.GetParameters.expand = "space,version,ancestors"
         }
 

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -72,7 +72,9 @@ function Get-Page {
         [string]$Query,
 
         [ValidateRange(1, [int]::MaxValue)]
-        [int]$PageSize = 25
+        [int]$PageSize = 25,
+
+        [switch]$ExcludePageBody
     )
 
     BEGIN {
@@ -87,6 +89,11 @@ function Get-Page {
             expand = "space,version,body.storage,ancestors"
             limit  = $PageSize
         }
+
+        if($ExcludePageBody.IsPresent){
+            $iwParameters.GetParameters.expand = "space,version,ancestors"
+        }
+
         $iwParameters['OutputType'] = [ConfluencePS.Page]
     }
 

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -90,7 +90,7 @@ function Get-Page {
             limit  = $PageSize
         }
 
-        if($ExcludePageBody.IsPresent){
+        if($ExcludePageBody){
             $iwParameters.GetParameters.expand = "space,version,ancestors"
         }
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -96,6 +96,13 @@ Describe 'Integration Tests' -Tag Integration {
         { Get-ConfluenceSpace -Key $Key1 -ErrorAction Stop } | Should Throw
 
         # ACT
+        Get-ConfluenceSpace|Where-Object {
+            $_.Name -in @($Name1,$Name2)
+        }| ForEach-Object {
+            Write-Warning "Removing space: $($_.Name) $($_.key)"
+            Remove-ConfluenceSpace $_.Key -Force -ErrorAction Stop
+        }
+
         $NewSpace1 = $Space1 | New-ConfluenceSpace -ErrorAction Stop
         $NewSpace2 = New-ConfluenceSpace -Key $Key2 -Name $Name2 -Description $Description -ErrorAction Stop
 
@@ -146,11 +153,6 @@ Describe 'Integration Tests' -Tag Integration {
         $GetSpace1 = Get-ConfluenceSpace -Key $Key1
         $GetSpace2 = Get-ConfluenceSpace | Where-Object {$_.Name -like '*ter test sp*'}
         $GetSpace3 = Get-ConfluenceSpace @($Key1, $Key2)
-
-
-        $AllSpaces|ForEach-Object {
-            Write-Warning "Found space: Name = $($_.Name) Key = $($_.Key)"
-        }
 
         # ASSERT
         It 'returns an object with specific properties' {

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -147,6 +147,11 @@ Describe 'Integration Tests' -Tag Integration {
         $GetSpace2 = Get-ConfluenceSpace | Where-Object {$_.Name -like '*ter test sp*'}
         $GetSpace3 = Get-ConfluenceSpace @($Key1, $Key2)
 
+
+        $AllSpaces|ForEach-Object {
+            Write-Warning "Found space: Name = $($_.Name) Key = $($_.Key)"
+        }
+
         # ASSERT
         It 'returns an object with specific properties' {
             $AllSpaces | Should BeOfType [ConfluencePS.Space]

--- a/docs/en-US/commands/Get-ChildPage.md
+++ b/docs/en-US/commands/Get-ChildPage.md
@@ -16,14 +16,15 @@ Retrieve the child pages of a given wiki page or pages.
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceChildPage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <Int32> [-Recurse] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluenceChildPage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <Int32> [-Recurse] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ## DESCRIPTION
 
 Return all pages directly below the given page(s).
 
-Optionally, the -Recurse parameter will return all child pages, no matter how nested.
+Optionally, the -Recurse parameter will return all child pages, no matter how nested. 
+Pass the optional parameter -ExcludePageBody to avoid fetching the pages' HTML content.
 
 ## EXAMPLES
 
@@ -202,6 +203,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 18446744073709551615
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludePageBody
+
+Avoids fetching pages' body
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -18,36 +18,37 @@ Retrieve a listing of pages in your Confluence instance.
 ### byId (Default)
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>]   [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### byLabel
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### bySpace
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -SpaceKey <String> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -SpaceKey <String> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### byQuery
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-Query <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-Query <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### bySpaceObject
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -Space <Space> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -Space <Space> [-Title <String>] [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ## DESCRIPTION
 
 Return Confluence pages, filtered by ID, Name, or Space.
+Pass the optional parameter -ExcludePageBody to avoid fetching the pages' HTML content.
 
 ## EXAMPLES
 
@@ -95,6 +96,14 @@ Get-ConfluencePage -Query "mention = jSmith and creator != jSmith"
 ```
 
 Return all pages matching the query.
+
+### -------------------------- EXAMPLE 5 --------------------------
+
+```powershell
+Get-ConfluencePage -Label 'skywalker' -ExcludePageBody
+```
+
+Return all pages containing the label "skywalker" (case-insensitive) without their page content.
 
 ## PARAMETERS
 
@@ -348,6 +357,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 18446744073709551615
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludePageBody
+
+Avoids fetching pages' body
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

`Get-Page` and `Get-ChildPage` calls fetch page content along with its metadata. A new switch parameter has been introduced in order to avoid fetching page body.

### Motivation and Context

- Reduces result size where only metadata is required

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
