### PR TITLE
Adding the Personal Access Token to Set-ConfluenceInfo 

### DIFF
--- a/ConfluencePS/Private/Copy-CommonParameter.ps1
+++ b/ConfluencePS/Private/Copy-CommonParameter.ps1
@@ -31,7 +31,7 @@ function Copy-CommonParameter {
         [string[]]$AdditionalParameter,
 
         [Parameter(Mandatory = $false)]
-        [string[]]$DefaultParameter = @("Credential", "Certificate")
+        [string[]]$DefaultParameter = @("Credential", "Certificate","PersonalAccessToken")
     )
 
     [hashtable]$ht = @{}

--- a/ConfluencePS/Private/Invoke-WebRequest.ps1
+++ b/ConfluencePS/Private/Invoke-WebRequest.ps1
@@ -31,6 +31,9 @@ function Invoke-WebRequest {
         [System.Management.Automation.CredentialAttribute()]
         ${Credential},
 
+        [string]
+        ${PersonalAccessToken},
+
         [switch]
         ${UseDefaultCredentials},
 
@@ -99,6 +102,11 @@ function Invoke-WebRequest {
                 ))
             $PSBoundParameters["Headers"]["Authorization"] = "Basic $($SecureCreds)"
             $null = $PSBoundParameters.Remove("Credential")
+        }
+
+        if ($PersonalAccessToken) {
+            $PSBoundParameters["Headers"]["Authorization"] = "Bearer $PersonalAccessToken"
+            $null = $PSBoundParameters.Remove("PersonalAccessToken")
         }
 
         if ($InFile) {
@@ -296,6 +304,8 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
         begin {
             if ($Credential -and (-not ($Authentication))) {
                 $PSBoundParameters["Authentication"] = "Basic"
+            } elseif ($PersonalAccessToken -and (-not ($Authentication))) {
+                $PSBoundParameters["Authentication"] = "Bearer"
             }
             if ($InFile) {
                 $multipartContent = [System.Net.Http.MultipartFormDataContent]::new()

--- a/ConfluencePS/Public/Add-Attachment.ps1
+++ b/ConfluencePS/Public/Add-Attachment.ps1
@@ -12,6 +12,9 @@ function Add-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Add-Attachment.ps1
+++ b/ConfluencePS/Public/Add-Attachment.ps1
@@ -12,7 +12,8 @@ function Add-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Add-Attachment.ps1
+++ b/ConfluencePS/Public/Add-Attachment.ps1
@@ -6,13 +6,13 @@ function Add-Attachment {
     [OutputType([ConfluencePS.Attachment])]
     param(
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -30,7 +30,11 @@ function Add-Attachment {
         [Alias('ID')]
         [UInt64]$PageID,
 
-        [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true
+        )]
         [ValidateScript(
             {
                 if (-not (Test-Path $_ -PathType Leaf)) {

--- a/ConfluencePS/Public/Add-Label.ps1
+++ b/ConfluencePS/Public/Add-Label.ps1
@@ -12,7 +12,8 @@ function Add-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Add-Label.ps1
+++ b/ConfluencePS/Public/Add-Label.ps1
@@ -6,13 +6,13 @@ function Add-Label {
     [OutputType([ConfluencePS.ContentLabelSet])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Add-Label.ps1
+++ b/ConfluencePS/Public/Add-Label.ps1
@@ -12,6 +12,9 @@ function Add-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -9,7 +9,8 @@ function ConvertTo-StorageFormat {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -3,13 +3,13 @@ function ConvertTo-StorageFormat {
     [OutputType([String])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -22,7 +22,7 @@ function ConvertTo-StorageFormat {
             Mandatory = $true,
             ValueFromPipeline = $true
         )]
-        [string[]]$Content
+        [String[]]$Content
     )
 
     BEGIN {

--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -9,6 +9,9 @@ function ConvertTo-StorageFormat {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/ConvertTo-Table.ps1
+++ b/ConfluencePS/Public/ConvertTo-Table.ps1
@@ -28,8 +28,8 @@ function ConvertTo-Table {
         # This ForEach needed if the content wasn't piped in
         $Content | ForEach-Object {
             if ($Vertical) {
-                if ($HeaderGenerated) {$pipe = '|'}
-                else {$pipe = '||'}
+                if ($HeaderGenerated) { $pipe = '|' }
+                else { $pipe = '||' }
 
                 # Put an empty row between multiple tables (objects)
                 if ($Spacer) {

--- a/ConfluencePS/Public/Get-Attachment.ps1
+++ b/ConfluencePS/Public/Get-Attachment.ps1
@@ -3,13 +3,13 @@ function Get-Attachment {
     [OutputType([ConfluencePS.Attachment])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Get-Attachment.ps1
+++ b/ConfluencePS/Public/Get-Attachment.ps1
@@ -9,7 +9,8 @@ function Get-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Get-Attachment.ps1
+++ b/ConfluencePS/Public/Get-Attachment.ps1
@@ -9,6 +9,9 @@ function Get-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Get-AttachmentFile.ps1
+++ b/ConfluencePS/Public/Get-AttachmentFile.ps1
@@ -3,13 +3,13 @@ function Get-AttachmentFile {
     [OutputType([Bool])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Get-AttachmentFile.ps1
+++ b/ConfluencePS/Public/Get-AttachmentFile.ps1
@@ -9,7 +9,8 @@ function Get-AttachmentFile {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Get-AttachmentFile.ps1
+++ b/ConfluencePS/Public/Get-AttachmentFile.ps1
@@ -9,6 +9,9 @@ function Get-AttachmentFile {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,
@@ -59,8 +62,8 @@ function Get-AttachmentFile {
 
         foreach ($_Attachment in $Attachment) {
             $iwParameters['Uri'] = $_Attachment.URL
-            $iwParameters['Headers'] = @{"Accept" = $_Attachment.MediaType}
-            $iwParameters['OutFile'] = if ($Path) {Join-Path -Path $Path -ChildPath $_Attachment.Filename} else {$_Attachment.Filename}
+            $iwParameters['Headers'] = @{"Accept" = $_Attachment.MediaType }
+            $iwParameters['OutFile'] = if ($Path) { Join-Path -Path $Path -ChildPath $_Attachment.Filename } else { $_Attachment.Filename }
 
             $result = Invoke-Method @iwParameters
             (-not $result)

--- a/ConfluencePS/Public/Get-ChildPage.ps1
+++ b/ConfluencePS/Public/Get-ChildPage.ps1
@@ -9,7 +9,8 @@ function Get-ChildPage {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Get-ChildPage.ps1
+++ b/ConfluencePS/Public/Get-ChildPage.ps1
@@ -3,13 +3,13 @@ function Get-ChildPage {
     [OutputType([ConfluencePS.Page])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -27,12 +27,12 @@ function Get-ChildPage {
         [Alias('ID')]
         [UInt64]$PageID,
 
-        [switch]$Recurse,
+        [Switch]$Recurse,
 
         [ValidateRange(1, [UInt32]::MaxValue)]
         [UInt32]$PageSize = 25,
 
-        [switch]$ExcludePageBody
+        [Switch]$ExcludePageBody
     )
 
     BEGIN {

--- a/ConfluencePS/Public/Get-ChildPage.ps1
+++ b/ConfluencePS/Public/Get-ChildPage.ps1
@@ -9,6 +9,9 @@ function Get-ChildPage {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Get-Label.ps1
+++ b/ConfluencePS/Public/Get-Label.ps1
@@ -11,7 +11,8 @@ function Get-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Get-Label.ps1
+++ b/ConfluencePS/Public/Get-Label.ps1
@@ -11,6 +11,9 @@ function Get-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Get-Label.ps1
+++ b/ConfluencePS/Public/Get-Label.ps1
@@ -5,13 +5,13 @@ function Get-Label {
     [OutputType([ConfluencePS.ContentLabelSet])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -6,13 +6,13 @@ function Get-Page {
     [OutputType([ConfluencePS.Page])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -38,7 +38,7 @@ function Get-Page {
             ParameterSetName = "bySpaceObject"
         )]
         [Alias('Name')]
-        [string]$Title,
+        [String]$Title,
 
         [Parameter(
             Mandatory = $true,
@@ -48,7 +48,7 @@ function Get-Page {
             ParameterSetName = "byLabel"
         )]
         [Alias('Key')]
-        [string]$SpaceKey,
+        [String]$SpaceKey,
 
         [Parameter(
             Mandatory = $true,
@@ -66,19 +66,19 @@ function Get-Page {
             Mandatory = $true,
             ParameterSetName = "byLabel"
         )]
-        [string[]]$Label,
+        [String[]]$Label,
 
         [Parameter(
             Position = 0,
             Mandatory = $true,
             ParameterSetName = "byQuery"
         )]
-        [string]$Query,
+        [String]$Query,
 
         [ValidateRange(1, [UInt32]::MaxValue)]
         [UInt32]$PageSize = 25,
 
-        [switch]$ExcludePageBody
+        [Switch]$ExcludePageBody
     )
 
     BEGIN {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -12,7 +12,8 @@ function Get-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -12,6 +12,9 @@ function Get-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Get-Space.ps1
+++ b/ConfluencePS/Public/Get-Space.ps1
@@ -11,6 +11,9 @@ function Get-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Get-Space.ps1
+++ b/ConfluencePS/Public/Get-Space.ps1
@@ -5,13 +5,13 @@ function Get-Space {
     [OutputType([ConfluencePS.Space])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -23,7 +23,7 @@ function Get-Space {
             Position = 0
         )]
         [Alias('Key')]
-        [string[]]$SpaceKey,
+        [String[]]$SpaceKey,
 
         [ValidateRange(1, [UInt32]::MaxValue)]
         [UInt32]$PageSize = 25

--- a/ConfluencePS/Public/Get-Space.ps1
+++ b/ConfluencePS/Public/Get-Space.ps1
@@ -11,7 +11,8 @@ function Get-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -45,7 +45,8 @@ function Invoke-Method {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -12,8 +12,11 @@ function Invoke-Method {
     )]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute( "PSAvoidUsingEmptyCatchBlock", "" )]
     param (
-        [Parameter(Mandatory = $true)]
-        [uri]$Uri,
+        [Parameter(
+            Position = 0,
+            Mandatory = $true
+        )]
+        [Uri]$Uri,
 
         [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = "GET",
 
@@ -45,7 +48,7 @@ function Invoke-Method {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -45,6 +45,9 @@ function Invoke-Method {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/New-Page.ps1
+++ b/ConfluencePS/Public/New-Page.ps1
@@ -13,7 +13,8 @@ function New-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/New-Page.ps1
+++ b/ConfluencePS/Public/New-Page.ps1
@@ -13,6 +13,9 @@ function New-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/New-Page.ps1
+++ b/ConfluencePS/Public/New-Page.ps1
@@ -7,13 +7,13 @@ function New-Page {
     [OutputType([ConfluencePS.Page])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -34,24 +34,26 @@ function New-Page {
             ParameterSetName = 'byParameters'
         )]
         [Alias('Name')]
-        [string]$Title,
+        [String]$Title,
 
         [Parameter(ParameterSetName = 'byParameters')]
         [ValidateRange(1, [UInt64]::MaxValue)]
         [UInt64]$ParentID,
+
         [Parameter(ParameterSetName = 'byParameters')]
         [ConfluencePS.Page]$Parent,
 
         [Parameter(ParameterSetName = 'byParameters')]
-        [string]$SpaceKey,
+        [String]$SpaceKey,
+
         [Parameter(ParameterSetName = 'byParameters')]
         [ConfluencePS.Space]$Space,
 
         [Parameter(ParameterSetName = 'byParameters')]
-        [string]$Body,
+        [String]$Body,
 
         [Parameter(ParameterSetName = 'byParameters')]
-        [switch]$Convert
+        [Switch]$Convert
     )
 
     BEGIN {

--- a/ConfluencePS/Public/New-Space.ps1
+++ b/ConfluencePS/Public/New-Space.ps1
@@ -13,7 +13,8 @@ function New-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/New-Space.ps1
+++ b/ConfluencePS/Public/New-Space.ps1
@@ -7,13 +7,13 @@ function New-Space {
     [OutputType([ConfluencePS.Space])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -33,18 +33,18 @@ function New-Space {
             ParameterSetName = "byProperties"
         )]
         [Alias('Key')]
-        [string]$SpaceKey,
+        [String]$SpaceKey,
 
         [Parameter(
             Mandatory = $true,
             ParameterSetName = "byProperties"
         )]
-        [string]$Name,
+        [String]$Name,
 
         [Parameter(
             ParameterSetName = "byProperties"
         )]
-        [string]$Description
+        [String]$Description
     )
 
     BEGIN {

--- a/ConfluencePS/Public/New-Space.ps1
+++ b/ConfluencePS/Public/New-Space.ps1
@@ -13,6 +13,9 @@ function New-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Remove-Attachment.ps1
+++ b/ConfluencePS/Public/Remove-Attachment.ps1
@@ -12,7 +12,8 @@ function Remove-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Remove-Attachment.ps1
+++ b/ConfluencePS/Public/Remove-Attachment.ps1
@@ -12,6 +12,9 @@ function Remove-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Remove-Attachment.ps1
+++ b/ConfluencePS/Public/Remove-Attachment.ps1
@@ -6,13 +6,13 @@ function Remove-Attachment {
     [OutputType([Bool])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Remove-Label.ps1
+++ b/ConfluencePS/Public/Remove-Label.ps1
@@ -6,13 +6,13 @@ function Remove-Label {
     [OutputType([Bool])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -31,7 +31,7 @@ function Remove-Label {
         [UInt64[]]$PageID,
 
         [Parameter()]
-        [string[]]$Label
+        [String[]]$Label
     )
 
     BEGIN {

--- a/ConfluencePS/Public/Remove-Label.ps1
+++ b/ConfluencePS/Public/Remove-Label.ps1
@@ -12,6 +12,9 @@ function Remove-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Remove-Label.ps1
+++ b/ConfluencePS/Public/Remove-Label.ps1
@@ -12,7 +12,8 @@ function Remove-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Remove-Page.ps1
+++ b/ConfluencePS/Public/Remove-Page.ps1
@@ -12,7 +12,8 @@ function Remove-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Remove-Page.ps1
+++ b/ConfluencePS/Public/Remove-Page.ps1
@@ -12,6 +12,9 @@ function Remove-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Remove-Page.ps1
+++ b/ConfluencePS/Public/Remove-Page.ps1
@@ -6,13 +6,13 @@ function Remove-Page {
     [OutputType([Bool])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]

--- a/ConfluencePS/Public/Remove-Space.ps1
+++ b/ConfluencePS/Public/Remove-Space.ps1
@@ -13,7 +13,8 @@ function Remove-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Remove-Space.ps1
+++ b/ConfluencePS/Public/Remove-Space.ps1
@@ -13,6 +13,9 @@ function Remove-Space {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Remove-Space.ps1
+++ b/ConfluencePS/Public/Remove-Space.ps1
@@ -7,13 +7,13 @@ function Remove-Space {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', '')]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -28,9 +28,9 @@ function Remove-Space {
             ValueFromPipelineByPropertyName = $true
         )]
         [Alias('Key')]
-        [string[]]$SpaceKey,
+        [String[]]$SpaceKey,
 
-        [switch]$Force
+        [Switch]$Force
 
         # TODO: Probably an extra param later to loop checking the status & wait for completion?
     )

--- a/ConfluencePS/Public/Set-Attachment.ps1
+++ b/ConfluencePS/Public/Set-Attachment.ps1
@@ -12,6 +12,9 @@ function Set-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Set-Attachment.ps1
+++ b/ConfluencePS/Public/Set-Attachment.ps1
@@ -12,7 +12,8 @@ function Set-Attachment {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Set-Attachment.ps1
+++ b/ConfluencePS/Public/Set-Attachment.ps1
@@ -6,13 +6,13 @@ function Set-Attachment {
     [OutputType([ConfluencePS.Attachment])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -28,7 +28,7 @@ function Set-Attachment {
         [ConfluencePS.Attachment]$Attachment,
 
         # Path of the file to upload and attach
-        [Parameter( Mandatory )]
+        [Parameter( Mandatory = $true )]
         [ValidateScript(
             {
                 if (-not (Test-Path $_ -PathType Leaf)) {

--- a/ConfluencePS/Public/Set-Info.ps1
+++ b/ConfluencePS/Public/Set-Info.ps1
@@ -9,6 +9,8 @@ function Set-Info {
 
         [PSCredential]$Credential,
 
+        [string]$PersonalAccessToken,
+
         [UInt32]$PageSize,
 
         [switch]$PromptCredentials

--- a/ConfluencePS/Public/Set-Info.ps1
+++ b/ConfluencePS/Public/Set-Info.ps1
@@ -58,6 +58,11 @@ function Set-Info {
                 Add-ConfluenceDefaultParameter -Command $command -Parameter $parameter -Value $Credential
             }
 
+            $parameter = "PersonalAccessToken"
+            if ($PersonalAccessToken -and ($command.Parameters.Keys -contains $parameter)) {
+                Add-ConfluenceDefaultParameter -Command $command -Parameter $parameter -Value $PersonalAccessToken
+            }
+
             $parameter = "PageSize"
             if ($PageSize -and ($command.Parameters.Keys -contains $parameter)) {
                 Add-ConfluenceDefaultParameter -Command $command -Parameter $parameter -Value $PageSize

--- a/ConfluencePS/Public/Set-Info.ps1
+++ b/ConfluencePS/Public/Set-Info.ps1
@@ -5,15 +5,15 @@ function Set-Info {
         [Parameter(
             HelpMessage = 'Example = https://brianbunke.atlassian.net/wiki (/wiki for Cloud instances)'
         )]
-        [uri]$BaseURi,
+        [Uri]$BaseURi,
 
         [PSCredential]$Credential,
 
-        [string]$PersonalAccessToken,
+        [String]$PersonalAccessToken,
 
         [UInt32]$PageSize,
 
-        [switch]$PromptCredentials
+        [Switch]$PromptCredentials
     )
 
     BEGIN {
@@ -21,10 +21,10 @@ function Set-Info {
         function Add-ConfluenceDefaultParameter {
             param(
                 [Parameter(Mandatory = $true)]
-                [string]$Command,
+                [String]$Command,
 
                 [Parameter(Mandatory = $true)]
-                [string]$Parameter,
+                [String]$Parameter,
 
                 [Parameter(Mandatory = $true)]
                 $Value

--- a/ConfluencePS/Public/Set-Label.ps1
+++ b/ConfluencePS/Public/Set-Label.ps1
@@ -6,13 +6,13 @@ function Set-Label {
     [OutputType([ConfluencePS.ContentLabelSet])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -30,8 +30,8 @@ function Set-Label {
         [Alias('ID')]
         [UInt64[]]$PageID,
 
-        [Parameter(Mandatory = $true)]
-        [string[]]$Label
+        [Parameter( Mandatory = $true )]
+        [String[]]$Label
     )
 
     BEGIN {

--- a/ConfluencePS/Public/Set-Label.ps1
+++ b/ConfluencePS/Public/Set-Label.ps1
@@ -12,7 +12,8 @@ function Set-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Set-Label.ps1
+++ b/ConfluencePS/Public/Set-Label.ps1
@@ -12,6 +12,9 @@ function Set-Label {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Set-Page.ps1
+++ b/ConfluencePS/Public/Set-Page.ps1
@@ -13,7 +13,8 @@ function Set-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [PSCredential]$PersonalAccessToken,
+        [string]
+        $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
         [ValidateNotNull()]

--- a/ConfluencePS/Public/Set-Page.ps1
+++ b/ConfluencePS/Public/Set-Page.ps1
@@ -13,6 +13,9 @@ function Set-Page {
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
+        [PSCredential]$PersonalAccessToken,
+
+        [Parameter( Mandatory = $false )]
         [ValidateNotNull()]
         [System.Security.Cryptography.X509Certificates.X509Certificate]
         $Certificate,

--- a/ConfluencePS/Public/Set-Page.ps1
+++ b/ConfluencePS/Public/Set-Page.ps1
@@ -7,13 +7,13 @@ function Set-Page {
     [OutputType([ConfluencePS.Page])]
     param (
         [Parameter( Mandatory = $true )]
-        [uri]$ApiUri,
+        [Uri]$ApiUri,
 
         [Parameter( Mandatory = $false )]
         [PSCredential]$Credential,
 
         [Parameter( Mandatory = $false )]
-        [string]
+        [String]
         $PersonalAccessToken,
 
         [Parameter( Mandatory = $false )]
@@ -39,13 +39,13 @@ function Set-Page {
 
         [Parameter(ParameterSetName = 'byParameters')]
         [ValidateNotNullOrEmpty()]
-        [string]$Title,
+        [String]$Title,
 
         [Parameter(ParameterSetName = 'byParameters')]
-        [string]$Body,
+        [String]$Body,
 
         [Parameter(ParameterSetName = 'byParameters')]
-        [switch]$Convert,
+        [Switch]$Convert,
 
         [Parameter(ParameterSetName = 'byParameters')]
         [ValidateRange(1, [UInt64]::MaxValue)]

--- a/Tests/Build.Tests.ps1
+++ b/Tests/Build.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Validation of build environment" -Tag Unit {
         }
 
         It "has a version changelog that matches the manifest version" {
-            Configuration\Get-Metadata -Path $env:BHManifestToTest -PropertyName ModuleVersion | Should -BeLike "$changelogVersion*"
+            (Metadata\Import-Metadata -Path $env:BHManifestToTest).ModuleVersion | Should -BeLike "$changelogVersion*"
         }
     }
 }

--- a/docs/en-US/commands/Add-Attachment.md
+++ b/docs/en-US/commands/Add-Attachment.md
@@ -16,7 +16,9 @@ Add a new attachment to an existing Confluence page.
 ## SYNTAX
 
 ```powershell
-Add-ConfluenceAttachment -ApiUri <Uri> -Credential <PSCredential> [[-PageID] <UInt64>] -FilePath <String> [-WhatIf] [-Confirm]
+Add-ConfluenceAttachment -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64> -FilePath <String> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Add-Attachment.md
+++ b/docs/en-US/commands/Add-Attachment.md
@@ -82,6 +82,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Add-Label.md
+++ b/docs/en-US/commands/Add-Label.md
@@ -16,7 +16,9 @@ Add a new global label to an existing Confluence page.
 ## SYNTAX
 
 ```powershell
-Add-ConfluenceLabel -ApiUri <Uri> -Credential <PSCredential> [[-PageID] <UInt64[]>] -Label <Object> [-WhatIf] [-Confirm]
+Add-ConfluenceLabel -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID]  <UInt64[]> -Label <Object> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Add-Label.md
+++ b/docs/en-US/commands/Add-Label.md
@@ -91,6 +91,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/ConvertTo-StorageFormat.md
+++ b/docs/en-US/commands/ConvertTo-StorageFormat.md
@@ -16,7 +16,8 @@ Convert your content to Confluence's storage format.
 ## SYNTAX
 
 ```powershell
-ConvertTo-ConfluenceStorageFormat -ApiUri <Uri> -Credential <PSCredential> [-Content] <String>
+ConvertTo-ConfluenceStorageFormat -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>] [-Content] <String[]>
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/ConvertTo-StorageFormat.md
+++ b/docs/en-US/commands/ConvertTo-StorageFormat.md
@@ -79,6 +79,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-Attachment.md
+++ b/docs/en-US/commands/Get-Attachment.md
@@ -16,7 +16,10 @@ Retrieve the child Attachments of a given wiki Page.
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceAttachment -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> [-FileNameFilter <string>] [-MediaTypeFilter <string>] [-Skip <UInt64>] [-First <UInt64>] [-PageSize <UInt64>] [-IncludeTotalCount]
+Get-ConfluenceAttachment -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> [-FileNameFilter <string>] [-MediaTypeFilter <string>]
+ [-Skip <UInt64>] [-First <UInt64>] [-PageSize <UInt64>] [-IncludeTotalCount]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-Attachment.md
+++ b/docs/en-US/commands/Get-Attachment.md
@@ -97,6 +97,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-AttachmentFile.md
+++ b/docs/en-US/commands/Get-AttachmentFile.md
@@ -16,7 +16,9 @@ Retrieves the binary Attachment for a given Attachment object.
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceAttachmentFile -ApiUri <Uri> -Credential <PSCredential> [-Attachment] <Attachment[]> [-Path <string>]
+Get-ConfluenceAttachmentFile -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-Attachment] <Attachment[]> [-Path <string>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-AttachmentFile.md
+++ b/docs/en-US/commands/Get-AttachmentFile.md
@@ -82,6 +82,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-ChildPage.md
+++ b/docs/en-US/commands/Get-ChildPage.md
@@ -83,6 +83,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-ChildPage.md
+++ b/docs/en-US/commands/Get-ChildPage.md
@@ -16,7 +16,10 @@ Retrieve the child pages of a given wiki page or pages.
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceChildPage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64> [-Recurse] [-PageSize <UInt64>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluenceChildPage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64> [-Recurse] [-PageSize <UInt64>] [-IncludeTotalCount]
+ [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-Label.md
+++ b/docs/en-US/commands/Get-Label.md
@@ -80,6 +80,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-Label.md
+++ b/docs/en-US/commands/Get-Label.md
@@ -16,8 +16,10 @@ Retrieve all labels applied to the given object(s).
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceLabel -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> [-PageSize <UInt64>]
- [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluenceLabel -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> [-PageSize <UInt64>] [-IncludeTotalCount]
+ [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -141,6 +141,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate to use for the authentication with the REST Api.

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -18,31 +18,46 @@ Retrieve a listing of pages in your Confluence instance.
 ### byId (Default)
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
+ [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### byLabel
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <UInt32>]
+ [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### bySpace
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -SpaceKey <String> [-Title <String>] [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -SpaceKey <String> [-Title <String>] [-PageSize <UInt32>] [-IncludeTotalCount]
+ [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### byQuery
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-Query <String>] [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-Query] <String> [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
+ [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ### bySpaceObject
 
 ```powershell
-Get-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -Space <Space> [-Title <String>] [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -Space <Space> [-Title <String>] [-PageSize <UInt32>] [-IncludeTotalCount]
+ [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-Space.md
+++ b/docs/en-US/commands/Get-Space.md
@@ -90,6 +90,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Get-Space.md
+++ b/docs/en-US/commands/Get-Space.md
@@ -17,7 +17,10 @@ Retrieve a listing of spaces in your Confluence instance.
 ## SYNTAX
 
 ```powershell
-Get-ConfluenceSpace -ApiUri <Uri> -Credential <PSCredential> [[-SpaceKey] <String[]>] [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+Get-ConfluenceSpace -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [[-SpaceKey] <String[]>] [-PageSize <UInt32>] [-IncludeTotalCount]
+ [-Skip <UInt64>] [-First <UInt64>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Invoke-Method.md
+++ b/docs/en-US/commands/Invoke-Method.md
@@ -18,8 +18,9 @@ Invoke a specific call to a Confluence REST Api endpoint
 
 ```powershell
 Invoke-ConfluenceMethod [-URi] <Uri> [[-Method] <WebRequestMethod>] [[-Body] <String>] [-RawBody]
- [[-Headers] <Hashtable>] [[-GetParameters] <Hashtable>] [[-InFile] <String>] [[-OutFile] <String>]
- [[-OutputType] <Type>] [-Credential] <PSCredential> [[-Caller] <Object>] [-IncludeTotalCount] [-Skip <UInt64>]
+ [-Headers <Hashtable>] [-GetParameters <Hashtable>] [-InFile <String>] [-OutFile <String>]
+ [-OutputType <Type>] [-Credential <PSCredential>] [-PersonalAccessToken <String>]
+ [-Certificate <X509Certificate>] [-Caller <Object>] [-IncludeTotalCount] [-Skip <UInt64>]
  [-First <UInt64>] [<CommonParameters>]
 ```
 
@@ -224,7 +225,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -244,7 +245,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -262,7 +263,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -280,7 +281,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -299,7 +300,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -317,7 +318,23 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PersonalAccessToken
+
+The PersonalAccessToken you created in your Confluence User Settings.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -335,7 +352,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -351,7 +368,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: Named
 Default value: $PSCmdlet
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/commands/Invoke-Method.md
+++ b/docs/en-US/commands/Invoke-Method.md
@@ -17,11 +17,12 @@ Invoke a specific call to a Confluence REST Api endpoint
 ## SYNTAX
 
 ```powershell
-Invoke-ConfluenceMethod [-URi] <Uri> [[-Method] <WebRequestMethod>] [[-Body] <String>] [-RawBody]
- [-Headers <Hashtable>] [-GetParameters <Hashtable>] [-InFile <String>] [-OutFile <String>]
- [-OutputType <Type>] [-Credential <PSCredential>] [-PersonalAccessToken <String>]
- [-Certificate <X509Certificate>] [-Caller <Object>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [<CommonParameters>]
+Invoke-ConfluenceMethod [-URi] <Uri> [-Method <WebRequestMethod>] [-Body <String>]
+ [-RawBody] [-Headers <Hashtable>] [-GetParameters <Hashtable>] [-InFile <String>]
+ [-OutFile <String>] [-OutputType <Type>] [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-Caller <Object>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/New-Page.md
+++ b/docs/en-US/commands/New-Page.md
@@ -138,6 +138,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/New-Page.md
+++ b/docs/en-US/commands/New-Page.md
@@ -18,13 +18,18 @@ Create a new page on your Confluence instance.
 ### byParameters (Default)
 
 ```powershell
-New-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -Title <String> [-ParentID <UInt64>] [-Parent <Page>] [-SpaceKey <String>] [-Space <Space>] [-Body <String>] [-Convert] [-WhatIf] [-Confirm]
+New-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -Title <String> [-ParentID <UInt64>] [-Parent <Page>] [-SpaceKey <String>]
+ [-Space <Space>] [-Body <String>] [-Convert] [-WhatIf] [-Confirm]
 ```
 
 ### byObject
 
 ```powershell
-New-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
+New-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -InputObject <Page> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/New-Space.md
+++ b/docs/en-US/commands/New-Space.md
@@ -99,6 +99,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/New-Space.md
+++ b/docs/en-US/commands/New-Space.md
@@ -18,14 +18,17 @@ Create a new blank space on your Confluence instance.
 ### byObject (Default)
 
 ```powershell
-New-ConfluenceSpace -ApiUri <Uri> -Credential <PSCredential> -InputObject <Space> [-WhatIf] [-Confirm]
+New-ConfluenceSpace -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -InputObject <Space> [-WhatIf] [-Confirm]
 ```
 
 ### byProperties
 
 ```powershell
-New-ConfluenceSpace -ApiUri <Uri> -Credential <PSCredential> -SpaceKey <String> -Name <String>
- [-Description <String>] [-WhatIf] [-Confirm]
+New-ConfluenceSpace -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -SpaceKey <String> -Name <String> [-Description <String>] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Remove-Attachment.md
+++ b/docs/en-US/commands/Remove-Attachment.md
@@ -91,6 +91,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Remove-Attachment.md
+++ b/docs/en-US/commands/Remove-Attachment.md
@@ -16,7 +16,9 @@ Remove an Attachment.
 ## SYNTAX
 
 ```powershell
-Remove-ConfluenceAttachment -ApiUri <Uri> -Credential <PSCredential> [-Attachment] <Attachment[]> [-WhatIf] [-Confirm]
+Remove-ConfluenceAttachment -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-Attachment] <Attachment[]> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Remove-Label.md
+++ b/docs/en-US/commands/Remove-Label.md
@@ -91,6 +91,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Remove-Label.md
+++ b/docs/en-US/commands/Remove-Label.md
@@ -16,7 +16,9 @@ Remove a label from existing Confluence content.
 ## SYNTAX
 
 ```powershell
-Remove-ConfluenceLabel -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> [-Label <String[]>] [-WhatIf] [-Confirm]
+Remove-ConfluenceLabel -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> [-Label <String[]>] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Remove-Page.md
+++ b/docs/en-US/commands/Remove-Page.md
@@ -91,6 +91,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Remove-Page.md
+++ b/docs/en-US/commands/Remove-Page.md
@@ -16,7 +16,9 @@ Trash an existing Confluence page.
 ## SYNTAX
 
 ```powershell
-Remove-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> [-WhatIf] [-Confirm]
+Remove-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Remove-Space.md
+++ b/docs/en-US/commands/Remove-Space.md
@@ -83,6 +83,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Remove-Space.md
+++ b/docs/en-US/commands/Remove-Space.md
@@ -16,7 +16,9 @@ Remove an existing Confluence space.
 ## SYNTAX
 
 ```powershell
-Remove-ConfluenceSpace -ApiUri <Uri> -Credential <PSCredential> [-SpaceKey] <String[]> [-Force] [-WhatIf] [-Confirm]
+Remove-ConfluenceSpace -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-SpaceKey] <String[]> [-Force] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Set-Attachment.md
+++ b/docs/en-US/commands/Set-Attachment.md
@@ -16,7 +16,9 @@ Updates an existing attachment with a new file.
 ## SYNTAX
 
 ```powershell
-Set-ConfluenceAttachment -ApiUri <Uri> -Credential <PSCredential> [-Attachment] <Attachment> -FilePath <String> [-WhatIf] [-Confirm]
+Set-ConfluenceAttachment -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-Attachment] <Attachment> -FilePath <String> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Set-Attachment.md
+++ b/docs/en-US/commands/Set-Attachment.md
@@ -79,6 +79,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Set-Info.md
+++ b/docs/en-US/commands/Set-Info.md
@@ -16,7 +16,9 @@ Specify wiki location and authorization for use in this session's REST API reque
 ## SYNTAX
 
 ```powershell
-Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [-PersonalAccessToken <String>] [[-PageSize] <UInt32>] [-PromptCredentials]
+Set-ConfluenceInfo [-BaseURi <Uri>] [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageSize <UInt32>] [-PromptCredentials]
 ```
 
 ## DESCRIPTION
@@ -78,7 +80,7 @@ Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -PersonalAccessToken 
 ```
 
 Declare the URI of your Confluence instance and the Personal Access Token. 
-See: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
+See: <https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html>
 
 ## PARAMETERS
 
@@ -93,7 +95,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -109,7 +111,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -125,12 +127,11 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
 
 ### -PageSize
 
@@ -143,7 +144,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/commands/Set-Info.md
+++ b/docs/en-US/commands/Set-Info.md
@@ -16,7 +16,7 @@ Specify wiki location and authorization for use in this session's REST API reque
 ## SYNTAX
 
 ```powershell
-Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [-PersonalAccessToken <PersonalAccessToken>] [[-PageSize] <UInt32>] [-PromptCredentials]
+Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [-PersonalAccessToken <String>] [[-PageSize] <UInt32>] [-PromptCredentials]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Set-Info.md
+++ b/docs/en-US/commands/Set-Info.md
@@ -16,7 +16,7 @@ Specify wiki location and authorization for use in this session's REST API reque
 ## SYNTAX
 
 ```powershell
-Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [[-PageSize] <UInt32>] [-PromptCredentials]
+Set-ConfluenceInfo [[-BaseURi] <Uri>] [[-Credential] <PSCredential>] [-PersonalAccessToken <PersonalAccessToken>] [[-PageSize] <UInt32>] [-PromptCredentials]
 ```
 
 ## DESCRIPTION
@@ -70,6 +70,16 @@ Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -Credential $Cred
 Declare the URI of your Confluence instance and the credentials (username and
 password).
 
+### -------------------------- EXAMPLE 5 --------------------------
+
+```powershell
+$Pat = 'NDU1MTk4NzUyNTg3Om1I/FR61TJBC8hhJKXpOgJBC0Jk'
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -PersonalAccessToken $Pat
+```
+
+Declare the URI of your Confluence instance and the Personal Access Token. 
+See: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
+
 ## PARAMETERS
 
 ### -BaseURi
@@ -105,6 +115,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+The PersonalAccessToken you created in your Confluence User Settings.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
 ### -PageSize
 
 Default PageSize for the invocations.
@@ -116,7 +143,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/commands/Set-Label.md
+++ b/docs/en-US/commands/Set-Label.md
@@ -16,7 +16,9 @@ Set the labels applied to existing Confluence content.
 ## SYNTAX
 
 ```powershell
-Set-Label -ApiUri <Uri> -Credential <PSCredential> [-PageID] <UInt64[]> -Label <String[]> [-WhatIf] [-Confirm]
+Set-Label -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ [-PageID] <UInt64[]> -Label <String[]> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Set-Label.md
+++ b/docs/en-US/commands/Set-Label.md
@@ -82,6 +82,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Set-Page.md
+++ b/docs/en-US/commands/Set-Page.md
@@ -111,6 +111,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PersonalAccessToken
+
+Confluence's Personal Access Token for authentication.
+Value can be set persistently with Set-ConfluenceInfo.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Certificate
 
 Certificate for authentication.

--- a/docs/en-US/commands/Set-Page.md
+++ b/docs/en-US/commands/Set-Page.md
@@ -18,13 +18,18 @@ Edit an existing Confluence page.
 ### byParameters (Default)
 
 ```powershell
-Set-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -PageID <UInt64> [-Title <String>] [-Body <String>] [-Convert] [-ParentID <UInt64>] [-Parent <Page>] [-WhatIf] [-Confirm]
+Set-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -PageID <UInt64> [-Title <String>] [-Body <String>] [-Convert]
+ [-ParentID <UInt64>] [-Parent <Page>] [-WhatIf] [-Confirm]
 ```
 
 ### byObject
 
 ```powershell
-Set-ConfluencePage -ApiUri <Uri> -Credential <PSCredential> -InputObject <Page> [-WhatIf] [-Confirm]
+Set-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
+ [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
+ -InputObject <Page> [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

## Description

- Added the -PersonalAccessToken parameter to Set-Info and all module commands.
- Updated documentation for usage.

## Motivation and Context

The ability to use a Personal Access Token was added to the API, but not to the ConfluencePS module. This pull request will add this capability.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- I was not sure exactly how to do the Pester Test.
- [x] I have updated the documentation accordingly.
