### PR TITLE
Migrate ConfluencePS CI to GitHub Actions using shared org setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,18 @@ concurrency:
 on:
   pull_request:
     branches: [master]
+    paths-ignore: &paths-ignore
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - ".vscode/**"
+      - ".editorconfig"
+      - ".spelling"
   push:
     branches: [master]
+    paths-ignore: *paths-ignore
   workflow_dispatch:
 
 jobs:
@@ -28,7 +38,6 @@ jobs:
         with:
           name: Release
           path: ./Release/
-          overwrite: true
 
   test_windows_ps5:
     name: Test (Windows PS5)
@@ -72,9 +81,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: Windows-PS5-Tests
+          name: Windows-PS5-Unit-Tests
           path: Test*.xml
-          overwrite: true
 
   test_pwsh:
     name: Test (${{ matrix.name }})
@@ -111,8 +119,8 @@ jobs:
             Install-Module Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck -ErrorAction Stop
           }
           Import-Module Pester -RequiredVersion 4.10.1 -Force
-          # Documentation-tagged help tests currently depend on PS5-era common
-          # parameter shape; keep pwsh lanes focused on code/test portability.
+          # Legacy ConfluencePS help tests rely on Windows PowerShell-only
+          # common parameter expectations.
           Invoke-Build -Task Test -ExcludeTag "Integration", "Documentation"
         shell: pwsh
 
@@ -120,12 +128,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.name }}-Tests
+          name: ${{ matrix.name }}-Unit-Tests
           path: Test*.xml
-          overwrite: true
 
-  integration_cloud:
-    name: Integration Tests (Cloud)
+  smoke_tests:
+    name: Smoke Tests
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' ||
@@ -145,7 +152,7 @@ jobs:
           name: Release
           path: ./Release/
 
-      - name: Run integration tests
+      - name: Run smoke integration tests
         if: env.WikiURI != '' && env.WikiUser != '' && env.WikiPass != ''
         run: |
           $requiredPesterVersion = [version]'4.10.1'
@@ -167,14 +174,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: Integration-Tests
+          name: Smoke-Tests
           path: Test*.xml
-          overwrite: true
 
   ci-required:
     name: CI Result
     if: always()
-    needs: [build, test_windows_ps5, test_pwsh, integration_cloud]
+    needs: [build, test_windows_ps5, test_pwsh, smoke_tests]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
-       github.actor != 'dependabot[bot]' &&
-       secrets.WikiURI != '' &&
-       secrets.WikiUser != '' &&
-       secrets.WikiPass != '')
+       github.actor != 'dependabot[bot]')
     env:
       WikiURI: ${{ secrets.WikiURI }}
       WikiUser: ${{ secrets.WikiUser }}
@@ -124,6 +121,7 @@ jobs:
           path: ./Release/
 
       - name: Run integration tests
+        if: env.WikiURI != '' && env.WikiUser != '' && env.WikiPass != ''
         run: |
           Import-Module Pester -RequiredVersion 4.10.1 -Force
           Invoke-Build -Task Test -Tag "Integration" -ExcludeTag ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,17 @@ jobs:
 
       - name: Test
         run: |
+          $requiredPesterVersion = [version]'4.10.1'
+          $installedPester = Get-Module -ListAvailable -Name Pester |
+            Where-Object { $_.Version -eq $requiredPesterVersion } |
+            Select-Object -First 1
+          if (-not $installedPester) {
+            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+              Register-PSRepository -Default -ErrorAction SilentlyContinue
+            }
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue
+            Install-Module Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck -ErrorAction Stop
+          }
           Import-Module Pester -RequiredVersion 4.10.1 -Force
           Invoke-Build -Task Test
         shell: powershell
@@ -86,6 +97,17 @@ jobs:
 
       - name: Test
         run: |
+          $requiredPesterVersion = [version]'4.10.1'
+          $installedPester = Get-Module -ListAvailable -Name Pester |
+            Where-Object { $_.Version -eq $requiredPesterVersion } |
+            Select-Object -First 1
+          if (-not $installedPester) {
+            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+              Register-PSRepository -Default -ErrorAction SilentlyContinue
+            }
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue
+            Install-Module Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck -ErrorAction Stop
+          }
           Import-Module Pester -RequiredVersion 4.10.1 -Force
           # Documentation-tagged help tests currently depend on PS5-era common
           # parameter shape; keep pwsh lanes focused on code/test portability.
@@ -123,6 +145,17 @@ jobs:
       - name: Run integration tests
         if: env.WikiURI != '' && env.WikiUser != '' && env.WikiPass != ''
         run: |
+          $requiredPesterVersion = [version]'4.10.1'
+          $installedPester = Get-Module -ListAvailable -Name Pester |
+            Where-Object { $_.Version -eq $requiredPesterVersion } |
+            Select-Object -First 1
+          if (-not $installedPester) {
+            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+              Register-PSRepository -Default -ErrorAction SilentlyContinue
+            }
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue
+            Install-Module Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck -ErrorAction Stop
+          }
           Import-Module Pester -RequiredVersion 4.10.1 -Force
           Invoke-Build -Task Test -Tag "Integration" -ExcludeTag ""
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           name: Release
           path: ./Release/
+          overwrite: true
 
   test_windows_ps5:
     name: Test (Windows PS5)
@@ -73,6 +74,7 @@ jobs:
         with:
           name: Windows-PS5-Tests
           path: Test*.xml
+          overwrite: true
 
   test_pwsh:
     name: Test (${{ matrix.name }})
@@ -120,6 +122,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-Tests
           path: Test*.xml
+          overwrite: true
 
   integration_cloud:
     name: Integration Tests (Cloud)
@@ -166,6 +169,7 @@ jobs:
         with:
           name: Integration-Tests
           path: Test*.xml
+          overwrite: true
 
   ci-required:
     name: CI Result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,155 @@
+name: CI
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/.github/actions/setup-powershell@master
+
+      - name: Build
+        run: Invoke-Build -Task ShowInfo, Clean, Build
+        shell: pwsh
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Release
+          path: ./Release/
+
+  test_windows_ps5:
+    name: Test (Windows PS5)
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/.github/actions/setup-powershell@master
+        with:
+          ps-version: "5"
+          skip-setup: "true"
+
+      - name: Setup dependencies
+        run: ./Tools/setup.ps1
+        shell: powershell
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: Release
+          path: ./Release/
+
+      - name: Test
+        run: |
+          Import-Module Pester -RequiredVersion 4.10.1 -Force
+          Invoke-Build -Task Test
+        shell: powershell
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Windows-PS5-Tests
+          path: Test*.xml
+
+  test_pwsh:
+    name: Test (${{ matrix.name }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-latest, name: "Windows PS7" }
+          - { os: ubuntu-latest, name: "Ubuntu" }
+          - { os: macos-latest, name: "macOS" }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/.github/actions/setup-powershell@master
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: Release
+          path: ./Release/
+
+      - name: Test
+        run: |
+          Import-Module Pester -RequiredVersion 4.10.1 -Force
+          # Documentation-tagged help tests currently depend on PS5-era common
+          # parameter shape; keep pwsh lanes focused on code/test portability.
+          Invoke-Build -Task Test -ExcludeTag "Integration", "Documentation"
+        shell: pwsh
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.name }}-Tests
+          path: Test*.xml
+
+  integration_cloud:
+    name: Integration Tests (Cloud)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]' &&
+       secrets.WikiURI != '' &&
+       secrets.WikiUser != '' &&
+       secrets.WikiPass != '')
+    env:
+      WikiURI: ${{ secrets.WikiURI }}
+      WikiUser: ${{ secrets.WikiUser }}
+      WikiPass: ${{ secrets.WikiPass }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/.github/actions/setup-powershell@master
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: Release
+          path: ./Release/
+
+      - name: Run integration tests
+        run: |
+          Import-Module Pester -RequiredVersion 4.10.1 -Force
+          Invoke-Build -Task Test -Tag "Integration" -ExcludeTag ""
+        shell: pwsh
+
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Integration-Tests
+          path: Test*.xml
+
+  ci-required:
+    name: CI Result
+    if: always()
+    needs: [build, test_windows_ps5, test_pwsh, integration_cloud]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate job results
+        shell: bash
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "Job results:"
+          echo "$results"
+          if echo "$results" | grep -E '"result":[[:space:]]*"(failure|cancelled)"' > /dev/null; then
+            echo "::error::One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."


### PR DESCRIPTION
## Summary
- add a new GitHub Actions `CI` workflow for ConfluencePS with build, cross-platform tests, cloud integration, and a required aggregate result job
- consume the shared org action `AtlassianPS/.github/actions/setup-powershell@master` to centralize PowerShell module caching and dependency bootstrap
- keep legacy test compatibility by importing Pester 4.10.1 in CI test jobs, with `Documentation` tests scoped to the Windows PS5 lane

## Test plan
- [x] Run `Invoke-Build -Task ShowInfo, Clean, Build` locally in the `issue-219` branch
- [x] Run `Invoke-Build -Task Test -ExcludeTag 'Integration','Documentation'` locally in the `issue-219` branch
- [ ] Validate CI on PR (build + matrix + aggregate job)
- [ ] Trigger manual `workflow_dispatch` run on `issue-219`

Closes #219.

Made with [Cursor](https://cursor.com)