### PR TITLE
Migrate ConfluencePS to shared standards v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - name: Build
         run: Invoke-Build -Task ShowInfo, Clean, Build
@@ -45,7 +45,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
         with:
           ps-version: "5"
           skip-setup: "true"
@@ -97,7 +97,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - name: Download release artifact
         uses: actions/download-artifact@v8
@@ -144,7 +144,7 @@ jobs:
       WikiPass: ${{ secrets.WikiPass }}
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - name: Download release artifact
         uses: actions/download-artifact@v8

--- a/ConfluencePS.build.ps1
+++ b/ConfluencePS.build.ps1
@@ -205,12 +205,12 @@ task UpdateManifest GetNextVersion, {
     Import-Module $env:BHPSModuleManifest -Force
     $ModuleAlias = @(Get-Alias | Where-Object {$_.ModuleName -eq "$env:BHProjectName"})
 
-    BuildHelpers\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName ModuleVersion -Value $env:NextBuildVersion
+    Metadata\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName ModuleVersion -Value $env:NextBuildVersion
     # BuildHelpers\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName FileList -Value (Get-ChildItem "$env:BHBuildOutput/$env:BHProjectName" -Recurse).Name
     BuildHelpers\Set-ModuleFunctions -Name "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -FunctionsToExport ([string[]](Get-ChildItem "$env:BHBuildOutput/$env:BHProjectName/Public/*.ps1").BaseName)
-    BuildHelpers\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName AliasesToExport -Value ''
+    Metadata\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName AliasesToExport -Value ''
     if ($ModuleAlias) {
-        BuildHelpers\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName AliasesToExport -Value @($ModuleAlias.Name)
+        Metadata\Update-Metadata -Path "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1" -PropertyName AliasesToExport -Value @($ModuleAlias.Name)
     }
 }
 
@@ -228,6 +228,12 @@ task Test Init, {
     Assert-True { Test-Path $env:BHBuildOutput -PathType Container } "Release path must exist"
 
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
+    $pester4 = Get-Module -Name Pester -ListAvailable |
+        Where-Object { $_.Version -ge [Version]'4.10.0' -and $_.Version -lt [Version]'5.0.0' } |
+        Sort-Object -Property Version -Descending |
+        Select-Object -First 1
+    Assert-True ($null -ne $pester4) "Pester 4.10.x is required for ConfluencePS tests. Install a compatible Pester 4 release."
+    Import-Module Pester -RequiredVersion $pester4.Version -Force -ErrorAction Stop
 
     <# $params = @{
         Path    = "$env:BHBuildOutput/$env:BHProjectName"

--- a/ConfluencePS.build.ps1
+++ b/ConfluencePS.build.ps1
@@ -123,6 +123,9 @@ task ShowInfo Init, GetNextVersion, {
     Write-Build Gray ('OS Version:                 {0}' -f $OSVersion)
     Write-Build Gray
 }
+
+# Synopsis: Compatibility alias expected by shared setup action
+task ShowDebugInfo ShowInfo
 #endregion DebugInformation
 
 #region BuildRelease

--- a/ConfluencePS/Private/ConvertTo-Icon.ps1
+++ b/ConfluencePS/Private/ConvertTo-Icon.ps1
@@ -12,15 +12,15 @@ function ConvertTo-Icon {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Icon"
             [ConfluencePS.Icon](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                Path,
-                Width,
-                Height,
-                IsDefault
-            ))
+                        Path,
+                    Width,
+                    Height,
+                    IsDefault
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/ConvertTo-Label.ps1
+++ b/ConfluencePS/Private/ConvertTo-Label.ps1
@@ -12,14 +12,14 @@ function ConvertTo-Label {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Label"
             [ConfluencePS.Label](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                id,
-                name,
-                prefix
-            ))
+                        id,
+                    name,
+                    prefix
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/ConvertTo-Page.ps1
+++ b/ConfluencePS/Private/ConvertTo-Page.ps1
@@ -12,7 +12,7 @@ function ConvertTo-Page {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Page"
             [ConfluencePS.Page](ConvertTo-Hashtable -InputObject ($object | Select-Object `
@@ -23,22 +23,22 @@ function ConvertTo-Page {
                             if ($_.space) {
                                 ConvertTo-Space $_.space
                             }
-                            else {$null}
+                            else { $null }
                         }
                     },
                     @{Name = "version"; Expression = {
                             if ($_.version) {
                                 ConvertTo-Version $_.version
                             }
-                            else {$null}
+                            else { $null }
                         }
                     },
-                    @{Name = "body"; Expression = {$_.body.storage.value}},
+                    @{Name = "body"; Expression = { $_.body.storage.value } },
                     @{Name = "ancestors"; Expression = {
                             if ($_.ancestors) {
                                 ConvertTo-PageAncestor $_.ancestors
                             }
-                            else {$null}
+                            else { $null }
                         }
                     },
                     @{Name = "URL"; Expression = {
@@ -47,7 +47,7 @@ function ConvertTo-Page {
                             if ($_._links.webui) {
                                 "{0}{1}" -f $base, $_._links.webui
                             }
-                            else {$null}
+                            else { $null }
                         }
                     },
                     @{Name = "ShortURL"; Expression = {
@@ -56,7 +56,7 @@ function ConvertTo-Page {
                             if ($_._links.tinyui) {
                                 "{0}{1}" -f $base, $_._links.tinyui
                             }
-                            else {$null}
+                            else { $null }
                         }
                     }
                 ))

--- a/ConfluencePS/Private/ConvertTo-PageAncestor.ps1
+++ b/ConfluencePS/Private/ConvertTo-PageAncestor.ps1
@@ -12,14 +12,14 @@ function ConvertTo-PageAncestor {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Page (Ancestor)"
             [ConfluencePS.Page](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                id,
-                status,
-                title
-            ))
+                        id,
+                    status,
+                    title
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/ConvertTo-Space.ps1
+++ b/ConfluencePS/Private/ConvertTo-Space.ps1
@@ -12,28 +12,30 @@ function ConvertTo-Space {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Space"
             [ConfluencePS.Space](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                id,
-                key,
-                name,
-                @{Name = "description"; Expression = {$_.description.plain.value}},
-                @{Name = "Icon"; Expression = {
-                        if ($_.icon) {
-                            ConvertTo-Icon $_.icon
+                        id,
+                    key,
+                    name,
+                    @{Name = "description"; Expression = { $_.description.plain.value } },
+                    @{Name = "Icon"; Expression = {
+                            if ($_.icon) {
+                                ConvertTo-Icon $_.icon
+                            }
+                            else { $null }
                         }
-                        else {$null}
+                    },
+                    type,
+                    @{Name = "Homepage"; Expression = {
+                            if ($_.homepage -is [PSCustomObject]) {
+                                ConvertTo-Page $_.homepage
+                            }
+                            else { $null } # homepage might be a string
+                        }
                     }
-                },
-                type,
-                @{Name = "Homepage"; Expression = {
-                    if ($_.homepage -is [PSCustomObject]) {
-                            ConvertTo-Page $_.homepage
-                    } else {$null} # homepage might be a string
-                }}
-            ))
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/ConvertTo-User.ps1
+++ b/ConfluencePS/Private/ConvertTo-User.ps1
@@ -12,15 +12,15 @@ function ConvertTo-User {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to User"
             [ConfluencePS.User](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                username,
-                userKey,
-                @{Name = "profilePicture"; Expression = { ConvertTo-Icon $_.profilePicture }},
-                displayname
-            ))
+                        username,
+                    userKey,
+                    @{Name = "profilePicture"; Expression = { ConvertTo-Icon $_.profilePicture } },
+                    displayname
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/ConvertTo-Version.ps1
+++ b/ConfluencePS/Private/ConvertTo-Version.ps1
@@ -12,17 +12,17 @@ function ConvertTo-Version {
         $InputObject
     )
 
-    Process {
+    process {
         foreach ($object in $InputObject) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Converting Object to Version"
             [ConfluencePS.Version](ConvertTo-Hashtable -InputObject ($object | Select-Object `
-                @{Name = "by"; Expression = { ConvertTo-User $_.by }},
-                when,
-                friendlyWhen,
-                number,
-                message,
-                minoredit
-            ))
+                    @{Name = "by"; Expression = { ConvertTo-User $_.by } },
+                    when,
+                    friendlyWhen,
+                    number,
+                    message,
+                    minoredit
+                ))
         }
     }
 }

--- a/ConfluencePS/Private/Copy-CommonParameter.ps1
+++ b/ConfluencePS/Private/Copy-CommonParameter.ps1
@@ -31,7 +31,7 @@ function Copy-CommonParameter {
         [string[]]$AdditionalParameter,
 
         [Parameter(Mandatory = $false)]
-        [string[]]$DefaultParameter = @("Credential", "Certificate","PersonalAccessToken")
+        [string[]]$DefaultParameter = @("Credential", "Certificate", "PersonalAccessToken")
     )
 
     [hashtable]$ht = @{}

--- a/ConfluencePS/Private/Invoke-WebRequest.ps1
+++ b/ConfluencePS/Private/Invoke-WebRequest.ps1
@@ -136,7 +136,7 @@ Content-Type: application/octet-stream
                 $PSBoundParameters['OutBuffer'] = 1
             }
             $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Invoke-WebRequest', [System.Management.Automation.CommandTypes]::Cmdlet)
-            $scriptCmd = {& $wrappedCmd @PSBoundParameters }
+            $scriptCmd = { & $wrappedCmd @PSBoundParameters }
             $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
             $steppablePipeline.Begin($PSCmdlet)
         }
@@ -304,7 +304,8 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
         begin {
             if ($Credential -and (-not ($Authentication))) {
                 $PSBoundParameters["Authentication"] = "Basic"
-            } elseif ($PersonalAccessToken -and (-not ($Authentication))) {
+            }
+            elseif ($PersonalAccessToken -and (-not ($Authentication))) {
                 $PSBoundParameters["Authentication"] = "Bearer"
             }
             if ($InFile) {
@@ -327,7 +328,7 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
                     $PSBoundParameters['OutBuffer'] = 1
                 }
                 $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Invoke-WebRequest', [System.Management.Automation.CommandTypes]::Cmdlet)
-                $scriptCmd = {& $wrappedCmd @PSBoundParameters }
+                $scriptCmd = { & $wrappedCmd @PSBoundParameters }
                 $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
                 $steppablePipeline.Begin($PSCmdlet)
             }

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,5 +1,118 @@
+﻿# From https://github.com/PowerShell/PSScriptAnalyzer/blob/master/Engine/Settings/CodeFormattingStroustrup.psd1
+# Inspired by https://eslint.org/docs/rules/brace-style#stroustrup
 @{
-    Severity=@('Error','Warning')
-    # IncludeRules = @()
-    # ExcludeRules = @()
+    IncludeRules = @(
+        # CmdletDesign
+        'PSUseApprovedVerbs',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSShouldProcess',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSUseSingularNouns',
+        'PSMissingModuleManifestField',
+        'PSAvoidDefaultValueSwitchParameter',
+
+        # CodeFormattingStroustrup
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing',
+
+        # PSGallery
+        'PSUseApprovedVerbs',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSShouldProcess',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSUseSingularNouns',
+        'PSMissingModuleManifestField',
+        'PSAvoidDefaultValueSwitchParameter',
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingEmptyCatchBlock',
+        'PSUseCmdletCorrectly',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSAvoidUsingPositionalParameters',
+        'PSAvoidGlobalVars',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSAvoidUsingInvokeExpression',
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSUsePSCredentialType',
+        'PSDSC*',
+
+        # ScriptFunctions
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingEmptyCatchBlock',
+        'PSUseCmdletCorrectly',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSAvoidUsingPositionalParameters',
+        'PSAvoidGlobalVars',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSAvoidUsingInvokeExpression',
+
+        # ScriptSecurity
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSAvoidUsingConvertToSecureStringWithPlainText',
+        'PSUsePSCredentialType',
+        'PSAvoidUsingUserNameAndPasswordParams',
+
+        # ScriptingStyle
+        'PSProvideCommentHelp',
+        'PSAvoidUsingWriteHost'
+    )
+
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $false
+            CheckSeparator                          = $true
+            CheckParameter                          = $false
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing         = @{
+            Enable = $true
+        }
+
+        PSAvoidUsingCmdletAliases  = @{
+            Enable    = $true
+            Whitelist = @('Task')
+        }
+    }
 }

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -36,6 +36,7 @@ Describe "Help tests" -Tag Documentation {
     $DefaultParams = @(
         'Verbose'
         'Debug'
+        'ProgressAction'
         'ErrorAction'
         'WarningAction'
         'InformationAction'

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -29,4 +29,7 @@
         }
         Version    = "latest"
     }
+    'AtlassianPS.Standards' = @{
+        Version    = "0.1.2"
+    }
 }

--- a/Tools/setup.ps1
+++ b/Tools/setup.ps1
@@ -4,6 +4,25 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]
 param()
 
+$psScriptAnalyzerSettingsPath = Join-Path (Join-Path $PSScriptRoot '..') 'PSScriptAnalyzerSettings.psd1'
+function Sync-PSScriptAnalyzerSetting {
+    [CmdletBinding()]
+    param()
+
+    Write-Host "Syncing PSScriptAnalyzer settings from AtlassianPS.Standards"
+
+    try {
+        Import-Module AtlassianPS.Standards -RequiredVersion '0.1.2' -Force -ErrorAction Stop
+        $resolvedSettingsPath = Sync-AtlassianPSScriptAnalyzerSettings `
+            -DestinationPath $psScriptAnalyzerSettingsPath `
+            -ErrorAction Stop
+        Write-Host "Shared PSScriptAnalyzer settings synchronized to '$resolvedSettingsPath'."
+    }
+    catch {
+        throw "Unable to sync PSScriptAnalyzer settings from AtlassianPS.Standards. $($_.Exception.Message)"
+    }
+}
+
 # PowerShell 5.1 and bellow need the PSGallery to be intialized
 if (-not ($gallery = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
     Write-Host "Installing PackageProvider NuGet"
@@ -23,3 +42,5 @@ Install-Module InvokeBuild -Scope CurrentUser -Force
 
 Write-Host "Installing Dependencies"
 Invoke-Build -Task InstallDependencies
+
+Sync-PSScriptAnalyzerSetting


### PR DESCRIPTION
Phase 2 migration for ConfluencePS onto shared AtlassianPS.Standards resources.

What changed:
- switched CI setup steps to shared action AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
- pinned standards module references to 0.1.2 in setup/build requirements
- kept Confluence build/test behavior while using shared settings sync flow

Validation:
- Invoke-Build -Task Build, Test