### PR TITLE
Pin Confluence PSScriptAnalyzer to 1.25.0

### DIFF
--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -27,7 +27,7 @@
         Parameters = @{
             SkipPublisherCheck = $true
         }
-        Version    = "latest"
+        Version    = "1.25.0"
     }
     'AtlassianPS.Standards' = @{
         Version    = "0.1.2"


### PR DESCRIPTION
## Summary
- pin `PSScriptAnalyzer` in `Tools/build.requirements.psd1` from `latest` to `1.25.0`

## Why
Keep local lint prerequisites explicit and version-aligned with `AtlassianPS.Standards` to avoid mixed-version analyzer import issues.

## Validation
- `./Tools/setup.ps1`
- `Invoke-Build -Task Build, Test`
