### PR TITLE
Harden invoke retry behavior and trust page version messages

### DIFF
--- a/ConfluencePS/Private/ConvertTo-GetParameter.ps1
+++ b/ConfluencePS/Private/ConvertTo-GetParameter.ps1
@@ -16,7 +16,15 @@
     PROCESS {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Making HTTP get parameter string out of a hashtable"
         foreach ($key in $InputObject.Keys) {
-            $parameters += "$key=$($InputObject[$key])&"
+            $encodedKey = ConvertTo-URLEncoded -InputString ([string]$key)
+            $encodedValue = if ($null -eq $InputObject[$key]) {
+                ""
+            }
+            else {
+                ConvertTo-URLEncoded -InputString ([string]$InputObject[$key])
+            }
+
+            $parameters += "$encodedKey=$encodedValue&"
         }
     }
 

--- a/ConfluencePS/Private/Test-ServerResponse.ps1
+++ b/ConfluencePS/Private/Test-ServerResponse.ps1
@@ -1,0 +1,111 @@
+﻿function Test-ServerResponse {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [PSObject]$InputObject,
+
+        [Microsoft.PowerShell.Commands.WebRequestMethod]
+        $Method = [Microsoft.PowerShell.Commands.WebRequestMethod]::Get,
+
+        [Int32]$RetryCount = 0,
+
+        [Int32]$MaxRetries = 3
+    )
+
+    process {
+        if (-not $InputObject -or -not $InputObject.StatusCode) {
+            return
+        }
+
+        $statusCode = [int]$InputObject.StatusCode
+        if ($statusCode -notin @(429, 503)) {
+            return
+        }
+
+        if ($RetryCount -ge $MaxRetries) {
+            return
+        }
+
+        $idempotentMethods = @(
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Get
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Head
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Put
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Delete
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Options
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Trace
+        )
+        if ($Method -notin $idempotentMethods) {
+            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Not retrying non-idempotent method '$Method'."
+            return
+        }
+
+        $retryAfter = 0
+        $hasRetryAfterHeader = $false
+        $retryAfterHeader = $null
+
+        if ($InputObject.PSObject.Properties.Name -contains "Headers" -and $InputObject.Headers) {
+            $headers = $InputObject.Headers
+
+            if ($headers -is [System.Collections.IDictionary]) {
+                if ($headers.Contains("Retry-After")) {
+                    $hasRetryAfterHeader = $true
+                    $retryAfterHeader = [string]$headers["Retry-After"]
+                }
+            }
+            else {
+                if (($headers.PSObject.Properties.Name -contains "RetryAfter") -and $headers.RetryAfter) {
+                    $hasRetryAfterHeader = $true
+                    if ($headers.RetryAfter.Delta) {
+                        $retryAfter = [Math]::Ceiling($headers.RetryAfter.Delta.TotalSeconds)
+                    }
+                    elseif ($headers.RetryAfter.Date) {
+                        $retryAfter = [Math]::Ceiling(($headers.RetryAfter.Date.Value.ToUniversalTime() - (Get-Date).ToUniversalTime()).TotalSeconds)
+                    }
+                }
+
+                if (-not $hasRetryAfterHeader -and ($headers.PSObject.Methods.Name -contains "TryGetValues")) {
+                    $headerValues = [string[]]@()
+                    if ($headers.TryGetValues("Retry-After", [ref]$headerValues) -and $headerValues.Count -gt 0) {
+                        $hasRetryAfterHeader = $true
+                        $retryAfterHeader = [string]$headerValues[0]
+                    }
+                }
+            }
+        }
+
+        if ($hasRetryAfterHeader -and $retryAfter -le 0 -and $retryAfterHeader) {
+            $retryAfterSeconds = 0
+            if ([Int32]::TryParse($retryAfterHeader, [ref]$retryAfterSeconds)) {
+                $retryAfter = $retryAfterSeconds
+            }
+            else {
+                $retryAt = [DateTimeOffset]::MinValue
+                if ([DateTimeOffset]::TryParse($retryAfterHeader, [ref]$retryAt)) {
+                    $retryAfter = [Math]::Ceiling(($retryAt.ToUniversalTime() - (Get-Date).ToUniversalTime()).TotalSeconds)
+                }
+            }
+        }
+
+        if ($hasRetryAfterHeader -and $retryAfter -gt 0) {
+            # Respect server-provided Retry-After as a minimum wait value.
+            $retryDelay = [double]$retryAfter
+        }
+        else {
+            $retryAfter = [Math]::Pow(2, $RetryCount + 1) * 10
+
+            $maxRetryDelay = 60
+            $jitter = Get-Random -Minimum 0.5 -Maximum 1.0
+            $retryDelay = [Math]::Min($maxRetryDelay, $retryAfter) * $jitter
+        }
+
+        $statusName = switch ($statusCode) {
+            429 { "Too Many Requests" }
+            503 { "Service Unavailable" }
+            default { "Recoverable Error" }
+        }
+
+        Write-Warning "[$($MyInvocation.MyCommand.Name)] $statusName (HTTP $statusCode). Retrying in $([Math]::Round($retryDelay, 1)) seconds (attempt $($RetryCount + 1) of $MaxRetries)."
+        Start-Sleep -Seconds $retryDelay
+        return $true
+    }
+}

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -33,6 +33,9 @@
 
         [String]$OutFile,
 
+        [ValidateRange(0, [Int32]::MaxValue)]
+        [Int32]$TimeoutSec = 100,
+
         [ValidateSet(
             [ConfluencePS.Page],
             [ConfluencePS.Space],
@@ -92,6 +95,9 @@
         $splatParameters['UseBasicParsing'] = $true
         $splatParameters['ErrorAction'] = 'Stop'
         $splatParameters['Verbose'] = $false     # Overwrites verbose output
+        if ($TimeoutSec -gt 0) {
+            $splatParameters["TimeoutSec"] = $TimeoutSec
+        }
 
         #add 'start' query parameter if Paging with Skip is being used
         if (($PSCmdlet.PagingParameters) -and ($PSCmdlet.PagingParameters.Skip)) {
@@ -126,23 +132,94 @@
         # Invoke the API
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Invoking method $Method to URI $URi"
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Invoke-WebRequest with: $(([PSCustomObject]$splatParameters) | Out-String)"
-        try {
-            $webResponse = Invoke-WebRequest @splatParameters
-        }
-        catch {
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
-            $webResponse = $_
-            if ($webResponse.ErrorDetails) {
-                # In PowerShellCore (v6+), the response body is available as string
-                $responseBody = $webResponse.ErrorDetails.Message
+        $webException = $null
+        $retryCount = 0
+        $maxRetries = 3
+        $getResponseBody = {
+            param($Response)
+
+            if (-not $Response) {
+                return $null
             }
-            else {
-                $webResponse = $webResponse.Exception.Response
+
+            if ($Response.Content) {
+                if ($Response.Content -is [string]) {
+                    return [string]$Response.Content
+                }
+
+                if ($Response.Content -is [System.Net.Http.HttpContent]) {
+                    try {
+                        return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                    }
+                    catch {
+                    }
+                }
+
+                if ($Response.Content.PSObject.Methods.Name -contains "ReadAsStringAsync") {
+                    try {
+                        return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                    }
+                    catch {
+                    }
+                }
             }
+
+            if (($Response | Get-Member -Name "RawContentStream") -and $Response.RawContentStream) {
+                try {
+                    return [Text.Encoding]::UTF8.GetString($Response.RawContentStream.ToArray())
+                }
+                catch {
+                }
+            }
+
+            if ($Response | Get-Member -Name "GetResponseStream") {
+                try {
+                    $readStream = New-Object -TypeName System.IO.StreamReader -ArgumentList ($Response.GetResponseStream())
+                    $body = $readStream.ReadToEnd()
+                    $readStream.Close()
+                    return $body
+                }
+                catch {
+                }
+            }
+
+            return $null
         }
 
-        # Test response Headers if Confluence requires a CAPTCHA
-        Test-Captcha -InputObject $webResponse
+        do {
+            $responseBody = $null
+
+            try {
+                $webResponse = Invoke-WebRequest @splatParameters
+                $webException = $null
+            }
+            catch {
+                Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
+                $webException = $_
+                if ($webException.ErrorDetails) {
+                    # In PowerShellCore (v6+), the response body is available as string
+                    $responseBody = $webException.ErrorDetails.Message
+                }
+                $webResponse = $webException.Exception.Response
+
+                if (-not $webResponse) {
+                    throw $webException
+                }
+
+                if (-not $responseBody) {
+                    $responseBody = & $getResponseBody $webResponse
+                }
+            }
+
+            # Test response Headers if Confluence requires a CAPTCHA
+            Test-Captcha -InputObject $webResponse
+
+            $shouldRetry = Test-ServerResponse -InputObject $webResponse -Method $Method -RetryCount $retryCount -MaxRetries $maxRetries
+            if ($shouldRetry) {
+                $retryCount++
+            }
+        }
+        while ($shouldRetry)
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Executed WebRequest. Access `$webResponse to see details"
 
@@ -156,11 +233,8 @@
             if ($statusCode.value__ -ge 400) {
                 Write-Warning "Confluence returned HTTP error $($statusCode.value__) - $($statusCode)"
 
-                if ((!($responseBody)) -and ($webResponse | Get-Member -Name "GetResponseStream")) {
-                    # Retrieve body of HTTP response - this contains more useful information about exactly why the error occurred
-                    $readStream = New-Object -TypeName System.IO.StreamReader -ArgumentList ($webResponse.GetResponseStream())
-                    $responseBody = $readStream.ReadToEnd()
-                    $readStream.Close()
+                if (-not $responseBody) {
+                    $responseBody = & $getResponseBody $webResponse
                 }
 
                 Write-Verbose "[$($MyInvocation.MyCommand.Name)] Retrieved body of HTTP response for more information about the error (`$responseBody)"
@@ -173,20 +247,41 @@
                     $responseBody
                 )
 
+                $errorMessages = @()
                 try {
                     $responseObject = ConvertFrom-Json -InputObject $responseBody -ErrorAction Stop
                     if ($responseObject.message) {
-                        $errorItem.ErrorDetails = $responseObject.message
+                        $errorMessages += [string]$responseObject.message
                     }
-                    else {
-                        $errorItem.ErrorDetails = "An unknown error ocurred."
+                    if ($responseObject.errorMessages) {
+                        $errorMessages += @($responseObject.errorMessages | ForEach-Object { [string]$_ })
                     }
-
+                    if ($responseObject.errors) {
+                        if ($responseObject.errors -is [hashtable]) {
+                            $errorMessages += @($responseObject.errors.Values | ForEach-Object { [string]$_ })
+                        }
+                        elseif (($responseObject.errors -is [System.Management.Automation.PSObject]) -and ($responseObject.errors -isnot [string])) {
+                            $errorMessages += @($responseObject.errors.PSObject.Properties | ForEach-Object { [string]$_.Value })
+                        }
+                        else {
+                            $errorMessages += @($responseObject.errors | ForEach-Object { [string]$_ })
+                        }
+                    }
                 }
                 catch {
-                    $errorItem.ErrorDetails = "An unknown error ocurred."
+                    # Fall back to raw response body below.
                 }
 
+                if ($errorMessages.Count -eq 0) {
+                    if ($responseBody) {
+                        $errorMessages = @([string]$responseBody)
+                    }
+                    else {
+                        $errorMessages = @("An unknown error occurred.")
+                    }
+                }
+
+                $errorItem.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(($errorMessages -join [Environment]::NewLine))
                 $Caller.WriteError($errorItem)
             }
             else {
@@ -229,7 +324,7 @@
                                 $script:PSDefaultParameterValues.Remove("$($MyInvocation.MyCommand.Name):GetParameters")
                                 $script:PSDefaultParameterValues.Remove("$($MyInvocation.MyCommand.Name):IncludeTotalCount")
 
-                                $parameters = Copy-CommonParameter -InputObject $PSBoundParameters -AdditionalParameter @("Method", "Headers", "OutputType")
+                                $parameters = Copy-CommonParameter -InputObject $PSBoundParameters -AdditionalParameter @("Method", "Headers", "OutputType", "TimeoutSec")
                                 $parameters['Uri'] = "{0}{1}" -f $response._links.base, $response._links.next
 
                                 Write-Verbose "NEXT PAGE: $($parameters["Uri"])"

--- a/ConfluencePS/Public/Set-Page.ps1
+++ b/ConfluencePS/Public/Set-Page.ps1
@@ -95,6 +95,9 @@
             "byObject" {
                 $iwParameters["Uri"] = $resourceApi -f $InputObject.ID
                 $Content.version.number = ++$InputObject.Version.Number
+                if ($null -ne $InputObject.Version.Message) {
+                    $Content.version.message = $InputObject.Version.Message
+                }
                 $Content.title = $InputObject.Title
                 $Content.body.storage.value = $InputObject.Body
                 # if ($InputObject.Ancestors) {

--- a/Tests/Functions/Invoke-Method.Tests.ps1
+++ b/Tests/Functions/Invoke-Method.Tests.ps1
@@ -1,0 +1,225 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment -CallerPath $PSScriptRoot
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope ConfluencePS {
+    Describe "Invoke-Method" -Tag 'Unit' {
+        BeforeAll {
+            if (-not ("ConfluencePS.Tests.FakeHttpException" -as [Type])) {
+                Add-Type -TypeDefinition @"
+namespace ConfluencePS.Tests {
+    using System;
+
+    public class FakeHttpException : Exception {
+        public object Response { get; private set; }
+
+        public FakeHttpException(string message, object response) : base(message) {
+            this.Response = response;
+        }
+    }
+}
+"@
+            }
+
+            function script:New-FakeWebResponse {
+                param(
+                    [int]$StatusCode = 200,
+                    [string]$Json = '{"results":[]}',
+                    [hashtable]$Headers = @{}
+                )
+
+                [PSCustomObject]@{
+                    StatusCode       = [System.Net.HttpStatusCode]$StatusCode
+                    Content          = $Json
+                    RawContentStream = [System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($Json))
+                    Headers          = $Headers
+                }
+            }
+
+            Mock Set-TlsLevel -ModuleName ConfluencePS {}
+            Mock Test-Captcha -ModuleName ConfluencePS {}
+            Mock Start-Sleep -ModuleName ConfluencePS {}
+        }
+
+        BeforeEach {
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                New-FakeWebResponse -StatusCode 200 -Json '{"results":[]}'
+            }
+        }
+
+        It "URL-encodes GET parameters before invoking the request" {
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -GetParameters @{
+                "sp ace" = "hello/world & me"
+            } -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -ParameterFilter {
+                $Uri.Query -match 'sp(\+|%20)ace=hello%2fworld(\+|%20)%26(\+|%20)me'
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "forwards default TimeoutSec to Invoke-WebRequest" {
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -ParameterFilter {
+                $TimeoutSec -eq 100
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "forwards explicit TimeoutSec to Invoke-WebRequest" {
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -TimeoutSec 30 -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -ParameterFilter {
+                $TimeoutSec -eq 30
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "omits TimeoutSec from Invoke-WebRequest when TimeoutSec is 0" {
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -TimeoutSec 0 -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -ParameterFilter {
+                -not $PSBoundParameters.ContainsKey("TimeoutSec")
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "retries once on HTTP 429 and continues successfully" {
+            $script:invokeCount = 0
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                if ($script:invokeCount -eq 0) {
+                    $script:invokeCount++
+                    New-FakeWebResponse -StatusCode 429 -Json '{"message":"rate limited"}' -Headers @{ "Retry-After" = "0" }
+                }
+                else {
+                    New-FakeWebResponse -StatusCode 200 -Json '{"results":[]}'
+                }
+            }
+
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -Exactly -Times 2 -Scope It
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -Exactly -Times 1 -Scope It
+        }
+
+        It "honors Retry-After without capping or downward jitter" {
+            $script:invokeCount = 0
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                if ($script:invokeCount -eq 0) {
+                    $script:invokeCount++
+                    New-FakeWebResponse -StatusCode 429 -Json '{"message":"rate limited"}' -Headers @{ "Retry-After" = "120" }
+                }
+                else {
+                    New-FakeWebResponse -StatusCode 200 -Json '{"results":[]}'
+                }
+            }
+
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -ParameterFilter {
+                [Math]::Abs([double]$Seconds - 120.0) -lt 0.001
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "does not retry non-idempotent methods by default" {
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                New-FakeWebResponse -StatusCode 429 -Json '{"message":"rate limited"}' -Headers @{ "Retry-After" = "1" }
+            }
+
+            { Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -Method Post -Body '{}' -ErrorAction Stop } | Should -Throw
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -Exactly -Times 0 -Scope It
+        }
+
+        It "propagates TimeoutSec to pagination follow-up calls" {
+            $script:timeouts = @()
+            $script:requestUris = @()
+            $script:invokeCount = 0
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                param($Uri, $TimeoutSec)
+
+                $script:timeouts += if ($null -ne $TimeoutSec) { [int]$TimeoutSec } else { $null }
+                $script:requestUris += $Uri.AbsoluteUri
+
+                if ($script:invokeCount -eq 0) {
+                    $script:invokeCount++
+                    return New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":1}],"_links":{"base":"https://example.com","next":"/wiki/rest/api/content?start=25"}}'
+                }
+
+                New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":2}]}'
+            }
+
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -TimeoutSec 33 -ErrorAction Stop
+
+            $script:timeouts | Should -HaveCount 2
+            $script:timeouts[0] | Should -Be 33
+            $script:timeouts[1] | Should -Be 33
+            $script:requestUris[1] | Should -Be "https://example.com/wiki/rest/api/content?start=25"
+        }
+
+        It "surfaces JSON errorMessages from HTTP error responses" {
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                New-FakeWebResponse -StatusCode 400 -Json '{"errorMessages":["Alpha issue","Beta issue"]}'
+            }
+
+            $thrown = $null
+            try {
+                $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails.Message | Should -Match "Alpha issue"
+        }
+
+        It "surfaces JSON errors object-map messages from HTTP error responses" {
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                New-FakeWebResponse -StatusCode 400 -Json '{"errors":{"title":"Title invalid","space":"Space denied"}}'
+            }
+
+            $thrown = $null
+            try {
+                $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails.Message | Should -Match "Title invalid"
+            $thrown.ErrorDetails.Message | Should -Match "Space denied"
+        }
+
+        It "reads HttpResponseMessage content when request throws" {
+            $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
+            $httpResponse.Content = [System.Net.Http.StringContent]::new(
+                '{"errors":{"field":"Field problem from response content"}}',
+                [System.Text.Encoding]::UTF8,
+                "application/json"
+            )
+
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                throw [ConfluencePS.Tests.FakeHttpException]::new("request failed", $httpResponse)
+            }
+
+            $thrown = $null
+            try {
+                $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails | Should -Not -BeNullOrEmpty
+            $thrown.ErrorDetails.Message | Should -Match "Field problem from response content"
+        }
+    }
+}

--- a/Tests/Functions/Set-Page.Tests.ps1
+++ b/Tests/Functions/Set-Page.Tests.ps1
@@ -1,0 +1,53 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment -CallerPath $PSScriptRoot
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope ConfluencePS {
+    Describe "Set-Page" -Tag 'Unit' {
+        BeforeAll {
+            $script:lastRequestBody = $null
+            Mock Invoke-Method -ModuleName ConfluencePS {
+                param(
+                    [string]$Body
+                )
+
+                $script:lastRequestBody = ConvertFrom-Json -InputObject $Body -ErrorAction Stop
+                [ConfluencePS.Page]::new()
+            }
+        }
+
+        It "includes version.message from input object even when unchanged" {
+            $page = [ConfluencePS.Page]::new()
+            $page.ID = 42
+            $page.Title = "Page title"
+            $page.Body = "<p>Body</p>"
+            $page.Version = [ConfluencePS.Version]::new()
+            $page.Version.Number = 7
+            $page.Version.Message = "Same message on purpose"
+
+            $null = Set-Page -ApiUri "https://example.com/wiki/rest/api" -InputObject $page -Confirm:$false
+
+            $script:lastRequestBody.version.number | Should -Be 8
+            $script:lastRequestBody.version.message | Should -Be "Same message on purpose"
+        }
+
+        It "omits version.message when input object message is not provided" {
+            $page = [ConfluencePS.Page]::new()
+            $page.ID = 43
+            $page.Title = "Page title"
+            $page.Body = "<p>Body</p>"
+            $page.Version = [ConfluencePS.Version]::new()
+            $page.Version.Number = 2
+
+            $null = Set-Page -ApiUri "https://example.com/wiki/rest/api" -InputObject $page -Confirm:$false
+
+            $script:lastRequestBody.version.number | Should -Be 3
+            $script:lastRequestBody.version.PSObject.Properties.Name | Should -Not -Contain "message"
+        }
+    }
+}

--- a/Tests/Functions/Test-ServerResponse.Tests.ps1
+++ b/Tests/Functions/Test-ServerResponse.Tests.ps1
@@ -1,0 +1,73 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment -CallerPath $PSScriptRoot
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope ConfluencePS {
+    Describe "Test-ServerResponse" -Tag 'Unit' {
+        BeforeAll {
+            Mock Start-Sleep -ModuleName ConfluencePS {}
+        }
+
+        BeforeEach {
+            Mock Get-Random -ModuleName ConfluencePS { 1.0 }
+        }
+
+        It "uses Retry-After HTTP-date as minimum retry delay" {
+            Mock Get-Date -ModuleName ConfluencePS { [DateTimeOffset]"2026-01-01T00:00:00Z" }
+            $response = [PSCustomObject]@{
+                StatusCode = 429
+                Headers    = @{ "Retry-After" = "Thu, 01 Jan 2026 00:02:00 GMT" }
+            }
+
+            $result = Test-ServerResponse -InputObject $response -Method Get -RetryCount 0 -MaxRetries 3
+
+            $result | Should -BeTrue
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -ParameterFilter {
+                [Math]::Abs([double]$Seconds - 120.0) -lt 0.001
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "uses Retry-After from HttpResponseHeaders RetryAfter property" {
+            $response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::TooManyRequests)
+            $response.Headers.RetryAfter = [System.Net.Http.Headers.RetryConditionHeaderValue]::new([TimeSpan]::FromSeconds(90))
+
+            $result = Test-ServerResponse -InputObject $response -Method Get -RetryCount 0 -MaxRetries 3
+
+            $result | Should -BeTrue
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -ParameterFilter {
+                [Math]::Abs([double]$Seconds - 90.0) -lt 0.001
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "uses capped exponential backoff when Retry-After is absent" {
+            $response = [PSCustomObject]@{
+                StatusCode = 429
+                Headers    = @{}
+            }
+
+            $result = Test-ServerResponse -InputObject $response -Method Get -RetryCount 2 -MaxRetries 3
+
+            $result | Should -BeTrue
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -ParameterFilter {
+                [Math]::Abs([double]$Seconds - 60.0) -lt 0.001
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "does not retry POST by default" {
+            $response = [PSCustomObject]@{
+                StatusCode = 503
+                Headers    = @{ "Retry-After" = "10" }
+            }
+
+            $result = Test-ServerResponse -InputObject $response -Method Post -RetryCount 0 -MaxRetries 3
+
+            $result | Should -BeNullOrEmpty
+            Should -Invoke -CommandName Start-Sleep -ModuleName ConfluencePS -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/docs/en-US/commands/Invoke-Method.md
+++ b/docs/en-US/commands/Invoke-Method.md
@@ -19,7 +19,7 @@ Invoke a specific call to a Confluence REST Api endpoint
 ```powershell
 Invoke-ConfluenceMethod [-URi] <Uri> [-Method <WebRequestMethod>] [-Body <String>]
  [-RawBody] [-Headers <Hashtable>] [-GetParameters <Hashtable>] [-InFile <String>]
- [-OutFile <String>] [-OutputType <Type>] [-Credential <PSCredential>]
+ [-OutFile <String>] [-TimeoutSec <Int32>] [-OutputType <Type>] [-Credential <PSCredential>]
  [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
  [-Caller <Object>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
  [<CommonParameters>]
@@ -284,6 +284,24 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutSec
+
+Timeout in seconds for the HTTP request.
+
+Set this value to `0` to disable the timeout in `Invoke-WebRequest`.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 100
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## Summary
- harden `Invoke-Method` with safer retry behavior, timeout propagation, and improved error parsing
- add `Test-ServerResponse` helper and unit tests covering retry/backoff and PS7 response handling
- update `Set-Page` to honor explicit `InputObject.Version.Message` and add unit coverage

## Validation
- `Invoke-Build -Task Lint`
- `Invoke-Build -Task Build, Test`