### PR TITLE
Fix duplicate-case JSON parsing in Invoke-Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])
 
+### Fixed
+
+- `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
+
 ## [2.5] 2019-03-27
 
 ### Added

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -88,6 +88,7 @@
         # load DefaultParameters for Invoke-WebRequest
         # as the global PSDefaultParameterValues is not used
         $PSDefaultParameterValues = $global:PSDefaultParameterValues
+        $convertFromJsonSupportsAsHashtable = (Get-Command -Name ConvertFrom-Json).Parameters.ContainsKey("AsHashtable")
 
         $splatParameters = Copy-CommonParameter -InputObject $PSBoundParameters -AdditionalParameter @("Uri", "Method", "InFile", "OutFile")
         $splatParameters['Headers'] = $_headers
@@ -249,7 +250,15 @@
 
                 $errorMessages = @()
                 try {
-                    $responseObject = ConvertFrom-Json -AsHashTable -InputObject $responseBody -ErrorAction Stop
+                    $convertFromJsonParameters = @{
+                        InputObject = $responseBody
+                        ErrorAction = 'Stop'
+                    }
+                    if ($convertFromJsonSupportsAsHashtable) {
+                        $convertFromJsonParameters['AsHashtable'] = $true
+                    }
+
+                    $responseObject = ConvertFrom-Json @convertFromJsonParameters
                     if ($responseObject.message) {
                         $errorMessages += [string]$responseObject.message
                     }
@@ -288,7 +297,23 @@
                 if ($webResponse.Content) {
                     try {
                         # API returned a Content: lets work with it
-                        $response = ConvertFrom-Json ([Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray()))
+                        $jsonResponseBody = [Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray())
+                        $convertFromJsonParameters = @{
+                            InputObject = $jsonResponseBody
+                            ErrorAction = 'Stop'
+                        }
+                        try {
+                            $response = ConvertFrom-Json @convertFromJsonParameters
+                        }
+                        catch {
+                            if (-not $convertFromJsonSupportsAsHashtable) {
+                                throw
+                            }
+
+                            # Confluence occasionally sends duplicate keys that differ only by case.
+                            $convertFromJsonParameters['AsHashtable'] = $true
+                            $response = ConvertFrom-Json @convertFromJsonParameters
+                        }
 
                         if ($null -ne $response.errors) {
                             Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received from; resolving"
@@ -303,7 +328,14 @@
                             }
                             # None paginated results / first page of pagination
                             $result = $response
-                            if (($response) -and ($response | Get-Member -Name results)) {
+                            $hasResults = $false
+                            if ($response -is [System.Collections.IDictionary]) {
+                                $hasResults = $response.Contains("results")
+                            }
+                            elseif (($response) -and ($response | Get-Member -Name results)) {
+                                $hasResults = $true
+                            }
+                            if ($hasResults) {
                                 $result = $response.results
                             }
                             if ($OutputType) {

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -249,7 +249,7 @@
 
                 $errorMessages = @()
                 try {
-                    $responseObject = ConvertFrom-Json -InputObject $responseBody -ErrorAction Stop
+                    $responseObject = ConvertFrom-Json -AsHashTable -InputObject $responseBody -ErrorAction Stop
                     if ($responseObject.message) {
                         $errorMessages += [string]$responseObject.message
                     }

--- a/Tests/Functions/Invoke-Method.Tests.ps1
+++ b/Tests/Functions/Invoke-Method.Tests.ps1
@@ -90,6 +90,21 @@ namespace ConfluencePS.Tests {
             } -Exactly -Times 1 -Scope It
         }
 
+        It "handles success payloads with duplicate JSON key casing" {
+            if (-not (Get-Command ConvertFrom-Json).Parameters.ContainsKey("AsHashtable")) {
+                Set-ItResult -Skipped -Because "ConvertFrom-Json -AsHashtable is unavailable in this PowerShell version."
+                return
+            }
+
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":1,"subType":"page","subtype":"page"}]}'
+            }
+
+            { $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -ErrorAction Stop } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -Exactly -Times 1 -Scope It
+        }
+
         It "retries once on HTTP 429 and continues successfully" {
             $script:invokeCount = 0
             Mock Invoke-WebRequest -ModuleName ConfluencePS {


### PR DESCRIPTION
## Summary
- rescue the core contributor change from #216 onto current master with preserved original author attribution
- handle duplicate JSON keys that differ only by case during response parsing
- add a regression test for duplicate key casing in success payloads

## Why this replaces #216
PR #216 includes 214 historical fork commits and cannot be cleanly merged. This branch cherry-picks only the contributor feature commit and then adds minimal hardening on top.

## Attribution
The original feature commit from @codethief was cherry-picked and preserved as commit author.

Closes #216