### PR TITLE
Align ConfluencePS workflow standards to v0.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@064643a6dfc2fbc00d332fc0b950375dbf87a291
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
 
       - run: Invoke-Build -Task Lint
         shell: pwsh
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@064643a6dfc2fbc00d332fc0b950375dbf87a291
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
 
       - run: Invoke-Build -Task Clean, Build
         shell: pwsh
@@ -66,7 +66,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@064643a6dfc2fbc00d332fc0b950375dbf87a291
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
         with:
           ps-version: "5"
           # Setup is run below in the powershell (PS 5.1) shell instead of pwsh,
@@ -106,7 +106,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@064643a6dfc2fbc00d332fc0b950375dbf87a291
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
 
       - uses: actions/download-artifact@v8
         with:
@@ -141,7 +141,7 @@ jobs:
       WikiPass: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@064643a6dfc2fbc00d332fc0b950375dbf87a291
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
 
       - name: Detect smoke secret configuration
         id: smoke_secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
       - run: Invoke-Build -Task Lint
         shell: pwsh
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
       - run: Invoke-Build -Task Clean, Build
         shell: pwsh
@@ -66,7 +66,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
         with:
           ps-version: "5"
           # Setup is run below in the powershell (PS 5.1) shell instead of pwsh,
@@ -106,7 +106,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
       - uses: actions/download-artifact@v8
         with:
@@ -141,7 +141,7 @@ jobs:
       WikiPass: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
       - name: Detect smoke secret configuration
         id: smoke_secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,9 @@ jobs:
     # Skip on fork PRs and Dependabot PRs: the shared cloud PAT secret is not exposed
     # in those contexts and the smoke run would fail. The ci-required
     # aggregator below treats skipped jobs as a pass, so fork PRs still get
-    # a green CI Result. First-party PRs and pushes to master gate on the
-    # smoke result, which in turn gates release.yml's artifact download
-    # (workflow_conclusion: success).
+    # a green CI Result. First-party PRs and pushes to master require smoke
+    # credentials and a successful smoke run, which in turn gates release.yml's
+    # artifact download (workflow_conclusion: success).
     if: github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]')
@@ -143,33 +143,24 @@ jobs:
       - uses: actions/checkout@v6
       - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
-      - name: Detect smoke secret configuration
-        id: smoke_secrets
+      - name: Validate smoke secret configuration
         run: |
-          $hasSecrets = -not (
-            [string]::IsNullOrWhiteSpace($env:WikiURI) -or
-            [string]::IsNullOrWhiteSpace($env:WikiUser) -or
-            [string]::IsNullOrWhiteSpace($env:WikiPass)
-          )
-          "has_secrets=$($hasSecrets.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
           if (
             [string]::IsNullOrWhiteSpace($env:WikiURI) -or
             [string]::IsNullOrWhiteSpace($env:WikiUser) -or
             [string]::IsNullOrWhiteSpace($env:WikiPass)
           ) {
-            Write-Warning "Skipping smoke tests because WikiURI, WikiUser, or WikiPass is not configured."
+            throw "Smoke tests require WikiURI, WikiUser, and WikiPass in first-party runs."
           }
         shell: pwsh
 
       - name: Run smoke integration tests
-        if: steps.smoke_secrets.outputs.has_secrets == 'true'
         run: |
           Invoke-Build -Task TestIntegration -Tag "Cloud"
         shell: pwsh
 
       - name: Upload integration test results
-        if: always() && steps.smoke_secrets.outputs.has_secrets == 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: Smoke-Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
         uses: MatteoCampinoti94/changelog-to-release@v1.0.6
         with:
           version-name: ${{ steps.release_ref.outputs.release_tag }}
+          configuration: ./.github/changelog.configuration.json
         if: ${{ hashFiles('CHANGELOG.md') != '' }}
 
       - name: Create Release and Upload Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,18 +48,18 @@ jobs:
           path: ./Release/
           if_no_artifact_found: fail
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
 
       - name: Publish to PowerShell Gallery
         shell: pwsh
         run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
           Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName ConfluencePS -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
 
       - name: Package release zip
         shell: pwsh
         run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
           $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName ConfluencePS
 
       - name: Create Release and Upload Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,23 +48,23 @@ jobs:
           path: ./Release/
           if_no_artifact_found: fail
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
-      - name: Publish to PowerShell Gallery
+      - run: Invoke-Build -Task Publish -VersionToPublish ${{ steps.release_ref.outputs.release_tag }}
+          -PSGalleryAPIKey ${{ secrets.PSGALLERY_API_KEY }}
         shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
-          Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName ConfluencePS -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
 
-      - name: Package release zip
-        shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
-          $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName ConfluencePS
+      - name: Cherry pick CHANGELOG.md
+        id: changelog
+        uses: MatteoCampinoti94/changelog-to-release@v1.0.6
+        with:
+          version-name: ${{ steps.release_ref.outputs.release_tag }}
+        if: ${{ hashFiles('CHANGELOG.md') != '' }}
 
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v3
         with:
+          body: ${{ steps.changelog.outputs.body }}
           tag_name: ${{ steps.release_ref.outputs.release_tag }}
           name: ${{ steps.release_ref.outputs.release_tag }}
           files: ./Release/ConfluencePS.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Migrated `Tools/setup.ps1` and `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards` bootstrap/update commands with deterministic standards-version resolution from `Tools/build.requirements.psd1`.
 - Replaced legacy PSDepend hashtable dependencies with pinned array requirements and aligned workflow setup action usage to the pinned standards action release.
 - Aligned release workflow setup/import steps to `AtlassianPS.Standards` `0.1.6`.
+- Aligned release pipeline to JiraPS publish contract (`Invoke-Build -Task Publish`) and changelog-driven release body generation.
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replaced legacy PSDepend hashtable dependencies with pinned array requirements and aligned workflow setup action usage to the pinned standards action release.
 - Aligned release workflow setup/import steps to `AtlassianPS.Standards` `0.1.6`.
 - Aligned release pipeline to JiraPS publish contract (`Invoke-Build -Task Publish`) and changelog-driven release body generation.
+- Added `changelog-to-release` configuration wiring and enforced first-party smoke credential validation while keeping fork/Dependabot PR smoke skipped.
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Migrated `Tools/setup.ps1` and `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards` bootstrap/update commands with deterministic standards-version resolution from `Tools/build.requirements.psd1`.
 - Replaced legacy PSDepend hashtable dependencies with pinned array requirements and aligned workflow setup action usage to the pinned standards action release.
+- Aligned release workflow setup/import steps to `AtlassianPS.Standards` `0.1.6`.
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])
 
 ### Fixed

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -30,11 +30,13 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
         $projectRoot = Get-RepositoryRoot
 
         $buildRequirementsPath = Join-Path -Path $projectRoot -ChildPath 'Tools/build.requirements.psd1'
-        $buildRequirements = Import-PowerShellDataFile -Path $buildRequirementsPath
-        $standardsRequirement = $buildRequirements |
-            Where-Object { $_.ModuleName -eq 'AtlassianPS.Standards' } |
-            Select-Object -First 1
-        $standardsVersion = [string] $standardsRequirement.RequiredVersion
+        $buildRequirementsContent = Get-Content -LiteralPath $buildRequirementsPath -Raw
+        $standardsVersionMatch = [regex]::Match(
+            $buildRequirementsContent,
+            'ModuleName\s*=\s*["'']AtlassianPS\.Standards["'']\s*;\s*RequiredVersion\s*=\s*["''](?<version>[^"'']+)["'']'
+        )
+        $standardsVersionMatch.Success | Should -BeTrue
+        $standardsVersion = $standardsVersionMatch.Groups['version'].Value
 
         $workflowPaths = Get-ChildItem -Path (Join-Path -Path $projectRoot -ChildPath '.github/workflows') -File -Filter '*.yml' |
             Select-Object -ExpandProperty FullName
@@ -43,7 +45,7 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
             $workflowContent = Get-Content -LiteralPath $workflowPath -Raw
             [regex]::Matches(
                 $workflowContent,
-                "AtlassianPS/AtlassianPS\.Standards/\.github/actions/setup-powershell@(?<sha>[0-9a-f]{40})(?:\s+#\s+v(?<version>[0-9]+\.[0-9]+\.[0-9]+))?"
+                "AtlassianPS/AtlassianPS\.Standards/\.github/actions/setup-powershell@(?<sha>[0-9a-f]{40})\s+#\s+v(?<version>[0-9]+\.[0-9]+\.[0-9]+)"
             ) | ForEach-Object {
                 [PSCustomObject]@{
                     WorkflowPath = $workflowPath
@@ -55,17 +57,8 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
 
         @($workflowActionMatches).Count | Should -BeGreaterThan 0
 
+        ($workflowActionMatches | Select-Object -ExpandProperty Version -Unique) | Should -Be @($standardsVersion)
         @($workflowActionMatches | Select-Object -ExpandProperty Sha -Unique).Count | Should -Be 1
-
-        $matchedVersions = @(
-            $workflowActionMatches |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_.Version) } |
-                Select-Object -ExpandProperty Version -Unique
-        )
-        if ($matchedVersions.Count -gt 0) {
-            $matchedVersions.Count | Should -Be 1
-            $matchedVersions[0] | Should -Be $standardsVersion
-        }
     }
 
     It 'reads AtlassianPS.Standards version from build.requirements in tool scripts' {


### PR DESCRIPTION
Summary: align ConfluencePS workflow setup-powershell pins to standards action commit 9a9367e (v0.1.6), align release workflow AtlassianPS.Standards imports to required version 0.1.6, and update changelog. Validation: Invoke-Build -Task Lint, Build, Test.