### PR TITLE
Rollback Confluence release workflow to Invoke-Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,9 @@ jobs:
 
       - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
-      - name: Publish to PowerShell Gallery
+      - run: Invoke-Build -Task Publish -VersionToPublish ${{ steps.release_ref.outputs.release_tag }}
+          -PSGalleryAPIKey ${{ secrets.PSGALLERY_API_KEY }}
         shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
-          Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName ConfluencePS -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
-
-      - name: Package release zip
-        shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
-          $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName ConfluencePS
 
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary
- replace direct standards function calls in .github/workflows/release.yml with Invoke-Build Task Publish
- pass VersionToPublish from resolved release tag to keep tag/version alignment
- keep artifact upload and homepage notification behavior unchanged

## Why
JiraPS is the reference pattern and uses the build abstraction for publish/version enforcement.

## Validation
- Invoke-Build -Task Build, Test