### PR TITLE
Align website docs indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ permalink: /module/ConfluencePS/
 # [ConfluencePS](https://atlassianps.org/module/ConfluencePS)
 
 [![GitHub release](https://img.shields.io/github/release/AtlassianPS/ConfluencePS.svg?style=for-the-badge)](https://github.com/AtlassianPS/ConfluencePS/releases/latest)
-[![Build Status](https://img.shields.io/vso/build/AtlassianPS/ConfluencePS/12/master.svg?style=for-the-badge)](https://dev.azure.com/AtlassianPS/ConfluencePS/_build/latest?definitionId=12)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/AtlassianPS/ConfluencePS/ci.yml?style=for-the-badge)](https://github.com/AtlassianPS/ConfluencePS/actions/workflows/ci.yml)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/ConfluencePS.svg?style=for-the-badge)](https://www.powershellgallery.com/packages/ConfluencePS)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)
 
@@ -62,14 +62,12 @@ Check out our guidelines on [Contributing](https://atlassianps.org/docs/Contribu
 
 ## Tested on
 
-|Configuration|Status|
-|-------------|------|
-|Windows Powershell v3|[![Build Status](https://img.shields.io/teamcity/http/build.powershell.org/s/ConfluencePS_TestOnPowerShellV3.svg?label=Build%20Status)](https://build.powershell.org/viewType.html?buildTypeId=ConfluencePS_TestOnPowerShellV3)|
-|Windows Powershell v4|[![Build Status](https://img.shields.io/teamcity/http/build.powershell.org/s/ConfluencePS_TestOnPowerShellV4.svg?label=Build%20Status)](https://build.powershell.org/viewType.html?buildTypeId=ConfluencePS_TestOnPowerShellV4)|
-|Windows Powershell v5.1|[![Build Status](https://img.shields.io/vso/build/AtlassianPS/ConfluencePS/12/master.svg?style=for-the-badge)](https://dev.azure.com/AtlassianPS/ConfluencePS/_build/latest?definitionId=12)|
-|Powershell Core (latest) on Windows|[![Build Status](https://img.shields.io/vso/build/AtlassianPS/ConfluencePS/12/master.svg?style=for-the-badge)](https://dev.azure.com/AtlassianPS/ConfluencePS/_build/latest?definitionId=12)|
-|Powershell Core (latest) on Ubuntu|[![Build Status](https://img.shields.io/vso/build/AtlassianPS/ConfluencePS/12/master.svg?style=for-the-badge)](https://dev.azure.com/AtlassianPS/ConfluencePS/_build/latest?definitionId=12)|
-|Powershell Core (latest) on MacOS|[![Build Status](https://img.shields.io/vso/build/AtlassianPS/ConfluencePS/12/master.svg?style=for-the-badge)](https://dev.azure.com/AtlassianPS/ConfluencePS/_build/latest?definitionId=12)|
+| Configuration | Status |
+| ------------- | ------ |
+| Windows PowerShell v5.1 | [CI workflow](https://github.com/AtlassianPS/ConfluencePS/actions/workflows/ci.yml) |
+| PowerShell 7 on Windows | [CI workflow](https://github.com/AtlassianPS/ConfluencePS/actions/workflows/ci.yml) |
+| PowerShell 7 on Ubuntu | [CI workflow](https://github.com/AtlassianPS/ConfluencePS/actions/workflows/ci.yml) |
+| PowerShell 7 on macOS | [CI workflow](https://github.com/AtlassianPS/ConfluencePS/actions/workflows/ci.yml) |
 
 ## Acknowledgements
 
@@ -82,6 +80,7 @@ Check out our guidelines on [Contributing](https://atlassianps.org/docs/Contribu
 * [Source Code]
 * [Latest Release]
 * [Submit an Issue]
+* [Contributing]
 * How you can help us: [List of Issues](https://github.com/AtlassianPS/ConfluencePS/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs)
 
 ## Disclaimer
@@ -99,6 +98,7 @@ Hopefully this is obvious, but:
   [Source Code]: <https://github.com/AtlassianPS/ConfluencePS>
   [Latest Release]: <https://github.com/AtlassianPS/ConfluencePS/releases/latest>
   [Submit an Issue]: <https://github.com/AtlassianPS/ConfluencePS/issues/new>
+  [Contributing]: https://atlassianps.org/docs/Contributing/
   [juneb]: <https://github.com/juneb>
   [brianbunke]: <https://github.com/brianbunke>
   [Check this out]: <https://github.com/juneb/PowerShellHelpDeepDive>

--- a/docs/en-US/about_ConfluencePS.md
+++ b/docs/en-US/about_ConfluencePS.md
@@ -133,6 +133,10 @@ Find us on GitHub or Slack, and let us know what you think.
 
 # SEE ALSO
 
+[Commands index](/docs/ConfluencePS/commands/)
+
+[Classes index](/docs/ConfluencePS/classes/)
+
 ConfluencePS on Github: <https://github.com/AtlassianPS/ConfluencePS>
 
 Confluence's REST API documentation: <https://docs.atlassian.com/atlassian-confluence/REST/latest/>

--- a/docs/en-US/classes/index.md
+++ b/docs/en-US/classes/index.md
@@ -1,0 +1,17 @@
+---
+layout: documentation
+permalink: /docs/ConfluencePS/classes/
+hide: true
+---
+# ConfluencePS classes
+
+| Class | Documentation |
+|---|---|
+| `ConfluencePS.Attachment` | [ConfluencePS.Attachment](/docs/ConfluencePS/classes/ConfluencePS.Attachment/) |
+| `ConfluencePS.ContentLabelSet` | [ConfluencePS.ContentLabelSet](/docs/ConfluencePS/classes/ConfluencePS.ContentLabelSet/) |
+| `ConfluencePS.Icon` | [ConfluencePS.Icon](/docs/ConfluencePS/classes/ConfluencePS.Icon/) |
+| `ConfluencePS.Label` | [ConfluencePS.Label](/docs/ConfluencePS/classes/ConfluencePS.Label/) |
+| `ConfluencePS.Page` | [ConfluencePS.Page](/docs/ConfluencePS/classes/ConfluencePS.Page/) |
+| `ConfluencePS.Space` | [ConfluencePS.Space](/docs/ConfluencePS/classes/ConfluencePS.Space/) |
+| `ConfluencePS.User` | [ConfluencePS.User](/docs/ConfluencePS/classes/ConfluencePS.User/) |
+| `ConfluencePS.Version` | [ConfluencePS.Version](/docs/ConfluencePS/classes/ConfluencePS.Version/) |

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -3,3 +3,33 @@ layout: documentation
 permalink: /docs/ConfluencePS/commands/
 hide: true
 ---
+# ConfluencePS commands
+
+ConfluencePS exports these commands with the `Confluence` default command prefix.
+The documentation pages use the source function names that back the exported commands.
+
+| Exported command | Documentation |
+|---|---|
+| `Add-ConfluenceAttachment` | [Add-Attachment](/docs/ConfluencePS/commands/Add-Attachment/) |
+| `Add-ConfluenceLabel` | [Add-Label](/docs/ConfluencePS/commands/Add-Label/) |
+| `ConvertTo-ConfluenceStorageFormat` | [ConvertTo-StorageFormat](/docs/ConfluencePS/commands/ConvertTo-StorageFormat/) |
+| `ConvertTo-ConfluenceTable` | [ConvertTo-Table](/docs/ConfluencePS/commands/ConvertTo-Table/) |
+| `Get-ConfluenceAttachment` | [Get-Attachment](/docs/ConfluencePS/commands/Get-Attachment/) |
+| `Get-ConfluenceAttachmentFile` | [Get-AttachmentFile](/docs/ConfluencePS/commands/Get-AttachmentFile/) |
+| `Get-ConfluenceChildPage` | [Get-ChildPage](/docs/ConfluencePS/commands/Get-ChildPage/) |
+| `Get-ConfluenceLabel` | [Get-Label](/docs/ConfluencePS/commands/Get-Label/) |
+| `Get-ConfluencePage` | [Get-Page](/docs/ConfluencePS/commands/Get-Page/) |
+| `Get-ConfluenceSpace` | [Get-Space](/docs/ConfluencePS/commands/Get-Space/) |
+| `Invoke-ConfluenceMethod` | [Invoke-Method](/docs/ConfluencePS/commands/Invoke-Method/) |
+| `New-ConfluencePage` | [New-Page](/docs/ConfluencePS/commands/New-Page/) |
+| `New-ConfluenceSpace` | [New-Space](/docs/ConfluencePS/commands/New-Space/) |
+| `Remove-ConfluenceAttachment` | [Remove-Attachment](/docs/ConfluencePS/commands/Remove-Attachment/) |
+| `Remove-ConfluenceLabel` | [Remove-Label](/docs/ConfluencePS/commands/Remove-Label/) |
+| `Remove-ConfluencePage` | [Remove-Page](/docs/ConfluencePS/commands/Remove-Page/) |
+| `Remove-ConfluenceSpace` | [Remove-Space](/docs/ConfluencePS/commands/Remove-Space/) |
+| `Set-ConfluenceAttachment` | [Set-Attachment](/docs/ConfluencePS/commands/Set-Attachment/) |
+| `Set-ConfluenceInfo` | [Set-Info](/docs/ConfluencePS/commands/Set-Info/) |
+| `Set-ConfluenceLabel` | [Set-Label](/docs/ConfluencePS/commands/Set-Label/) |
+| `Set-ConfluencePage` | [Set-Page](/docs/ConfluencePS/commands/Set-Page/) |
+
+For module overview and setup, see [about_ConfluencePS](/docs/ConfluencePS/).


### PR DESCRIPTION
## Summary
- move the ConfluencePS about topic to the docs root while preserving the public permalink
- populate command and class indexes for website rendering
- normalize README badges, tested platform table, and useful links

## Validation
- `./Tools/setup.ps1`
- focused help tests passed
- `Invoke-Build -Task Build, Test` passed: 139 tests