### PR TITLE
Revive AsPlainText storage conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added Confluence Data Center integration-test infrastructure: `docker-compose.yml` (moveworkforward `atlas-run-standalone` image), `Tools/Wait-ConfluenceServer.ps1`, and `StartConfluenceDocker` / `StopConfluenceDocker` build tasks.
 - Added `.github/workflows/integration_tests.yml` with parallel Cloud and Dockerized Data Center tracks (nightly schedule + manual dispatch input).
+- Added `ConvertTo-ConfluenceStorageFormat -AsPlainText` to publish literal text containing wiki markup characters without Confluence converting them to links, mentions, or macros (#178, [@empty03]).
 
 ### Changed
 
@@ -210,6 +211,7 @@ No changelog available for version `1.0` of ConfluencePS. `1.0` was created in l
 [@colhal]: https://github.com/colhal
 [@Dejulia489]: https://github.com/Dejulia489
 [@ebekker]: https://github.com/ebekker
+[@empty03]: https://github.com/empty03
 [@FelixMelchert]: https://github.com/FelixMelchert
 [@jkknorr]: https://github.com/jkknorr
 [@JohnAdders]: https://github.com/JohnAdders

--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -22,7 +22,10 @@
             Mandatory = $true,
             ValueFromPipeline = $true
         )]
-        [String[]]$Content
+        [String[]]$Content,
+
+        [Parameter()]
+        [Switch]$AsPlainText
     )
 
     BEGIN {
@@ -37,7 +40,15 @@
         $iwParameters['Uri'] = "$ApiUri/contentbody/convert/storage"
         $iwParameters['Method'] = 'Post'
 
+        if ($AsPlainText) {
+            $iwParameters.Remove('AsPlainText')
+        }
+
         foreach ($_content in $Content) {
+            if ($AsPlainText) {
+                $_content = [System.Web.HttpUtility]::HtmlEncode($_content)
+            }
+
             $iwParameters['Body'] = @{
                 value          = "$_content"
                 representation = 'wiki'

--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -39,14 +39,15 @@
         $iwParameters = Copy-CommonParameter -InputObject $PSBoundParameters
         $iwParameters['Uri'] = "$ApiUri/contentbody/convert/storage"
         $iwParameters['Method'] = 'Post'
-
-        if ($AsPlainText) {
-            $iwParameters.Remove('AsPlainText')
-        }
+        $plainTextMarkupPattern = '[!"#$%&''()*+,\-./:;<=>?@\[\\\]\^_`{|}~]'
 
         foreach ($_content in $Content) {
             if ($AsPlainText) {
-                $_content = [System.Web.HttpUtility]::HtmlEncode($_content)
+                $_content = [Regex]::Replace(
+                    $_content,
+                    $plainTextMarkupPattern,
+                    { param($match) "&#$([Int32][Char]$match.Value);" }
+                )
             }
 
             $iwParameters['Body'] = @{

--- a/Tests/Functions/ConvertTo-StorageFormat.Tests.ps1
+++ b/Tests/Functions/ConvertTo-StorageFormat.Tests.ps1
@@ -1,0 +1,46 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment -CallerPath $PSScriptRoot
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope ConfluencePS {
+    Describe "ConvertTo-StorageFormat" -Tag 'Unit' {
+        BeforeEach {
+            $script:lastRequestBody = $null
+            Mock Invoke-Method -ModuleName ConfluencePS {
+                param(
+                    [string]$Body
+                )
+
+                $script:lastRequestBody = ConvertFrom-Json -InputObject $Body -ErrorAction Stop
+                [PSCustomObject]@{ value = '<p>converted</p>' }
+            }
+        }
+
+        It "has an AsPlainText switch parameter" {
+            $command = Get-Command -Name ConvertTo-StorageFormat
+
+            $command.Parameters.ContainsKey("AsPlainText") | Should -BeTrue
+            $command.Parameters["AsPlainText"].ParameterType | Should -Be ([switch])
+        }
+
+        It "passes wiki content through unchanged by default" {
+            $result = ConvertTo-StorageFormat -ApiUri "https://example.com/wiki/rest/api" -Content '# @ [{]}'
+
+            $result | Should -Be '<p>converted</p>'
+            $script:lastRequestBody.value | Should -Be '# @ [{]}'
+            $script:lastRequestBody.representation | Should -Be 'wiki'
+        }
+
+        It "entity-encodes wiki markup before wiki-to-storage conversion" {
+            $null = ConvertTo-StorageFormat -ApiUri "https://example.com/wiki/rest/api" -Content 'h1. *bold* _italic_ !image.png! ||cell|| # @ [{]} <script>' -AsPlainText
+
+            $script:lastRequestBody.value | Should -Be 'h1&#46; &#42;bold&#42; &#95;italic&#95; &#33;image&#46;png&#33; &#124;&#124;cell&#124;&#124; &#35; &#64; &#91;&#123;&#93;&#125; &#60;script&#62;'
+            $script:lastRequestBody.representation | Should -Be 'wiki'
+        }
+    }
+}

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -259,6 +259,9 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $result3 | Should -BeExactly @($script:OutputString, $script:OutputString)
         }
         It 'can preserve wiki markup characters as literal text' {
+            $result4 | Should -Match 'h1\.'
+            $result4 | Should -Match '\*bold\*'
+            $result4 | Should -Match '!image\.png!'
             $result4 | Should -Not -Match '<h1|<strong|<ac:image'
         }
     }

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -241,6 +241,7 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $result1 = $script:InputString | ConvertTo-ConfluenceStorageFormat
             $result2 = ConvertTo-ConfluenceStorageFormat -Content $script:InputString
             $result3 = ConvertTo-ConfluenceStorageFormat -Content $script:InputString, $script:InputString
+            $result4 = ConvertTo-ConfluenceStorageFormat -Content 'h1. *bold* !image.png!' -AsPlainText
 
         }
 
@@ -250,11 +251,15 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $result1 | Should -BeOfType [String]
             $result2 | Should -BeOfType [String]
             $result3 | Should -BeOfType [String]
+            $result4 | Should -BeOfType [String]
         }
         It 'output matches the expected string' {
             $result1 | Should -BeExactly $script:OutputString
             $result2 | Should -BeExactly $script:OutputString
             $result3 | Should -BeExactly @($script:OutputString, $script:OutputString)
+        }
+        It 'can preserve wiki markup characters as literal text' {
+            $result4 | Should -Not -Match '<h1|<strong|<ac:image'
         }
     }
 

--- a/docs/en-US/commands/ConvertTo-StorageFormat.md
+++ b/docs/en-US/commands/ConvertTo-StorageFormat.md
@@ -18,6 +18,7 @@ Convert your content to Confluence's storage format.
 ```powershell
 ConvertTo-ConfluenceStorageFormat -ApiUri <Uri> [-Credential <PSCredential>]
  [-PersonalAccessToken <String>] [-Certificate <X509Certificate>] [-Content] <String[]>
+ [-AsPlainText]
 ```
 
 ## DESCRIPTION
@@ -43,6 +44,15 @@ Get-Date -Format s | ConvertTo-ConfluenceStorageFormat
 ```
 
 Pipe the current date/time in sortable format, returning the converted string.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```powershell
+$Body = ConvertTo-ConfluenceStorageFormat -Content 'Use @{ Name = "Value" } in PowerShell.' -AsPlainText
+```
+
+Entity-encodes the content before conversion so Confluence treats wiki markup
+characters as literal text instead of converting them to mentions, links, or macros.
 
 ## PARAMETERS
 
@@ -126,6 +136,23 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -AsPlainText
+
+Entity-encodes the content before conversion so Confluence treats wiki markup
+characters as literal text.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
## Attribution
This PR revives and completes the work originally contributed by @empty03 in #178.

The first commit in this PR, `d59f2c4` (`SwitchParameter -AsPlainText`), is cherry-picked from @empty03's original contribution and keeps their original author metadata:

> empty03 <57891206+empty03@users.noreply.github.com>

The follow-up commit only updates the implementation for the current codebase, fixes edge cases, and adds tests/docs so the original contribution can be merged safely.

## Summary
- revives original PR #178 by @empty03 with the original contributor commit preserved
- adds `ConvertTo-ConfluenceStorageFormat -AsPlainText` for publishing literal text containing Confluence wiki markup characters
- adds unit coverage, integration-suite coverage, command docs, and changelog attribution

## Validation
- `Invoke-Pester -Path 'Tests/Functions/ConvertTo-StorageFormat.Tests.ps1'`
- `Invoke-Build -Task Lint`
- `Invoke-Build -Task Build, Test`

## Notes
- replaces stale PR #178 with a current branch based on `master`
- live Cloud/Data Center integration tracks should still validate the Confluence API behavior in CI/manual integration runs
