### PR TITLE
Fix PersonalAccessToken on PowerShell Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
+- Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 
 ### Fixed
 

--- a/ConfluencePS/Private/Invoke-WebRequest.ps1
+++ b/ConfluencePS/Private/Invoke-WebRequest.ps1
@@ -205,6 +205,9 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
             [System.Management.Automation.CredentialAttribute()]
             ${Credential},
 
+            [string]
+            ${PersonalAccessToken},
+
             [switch]
             ${UseDefaultCredentials},
 
@@ -305,8 +308,9 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
             if ($Credential -and (-not ($Authentication))) {
                 $PSBoundParameters["Authentication"] = "Basic"
             }
-            elseif ($PersonalAccessToken -and (-not ($Authentication))) {
-                $PSBoundParameters["Authentication"] = "Bearer"
+            if ($PersonalAccessToken) {
+                $PSBoundParameters["Headers"]["Authorization"] = "Bearer $PersonalAccessToken"
+                $null = $PSBoundParameters.Remove("PersonalAccessToken")
             }
             if ($InFile) {
                 $multipartContent = [System.Net.Http.MultipartFormDataContent]::new()

--- a/Tests/Functions/Invoke-Method.Tests.ps1
+++ b/Tests/Functions/Invoke-Method.Tests.ps1
@@ -84,6 +84,23 @@ namespace ConfluencePS.Tests {
             } -Exactly -Times 1 -Scope It
         }
 
+        It "forwards PersonalAccessToken to Invoke-WebRequest" {
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -PersonalAccessToken "token-value" -ErrorAction Stop
+
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName ConfluencePS -ParameterFilter {
+                $PersonalAccessToken -eq "token-value"
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "supports PersonalAccessToken in the private Invoke-WebRequest wrapper" {
+            if ($PSVersionTable.PSVersion.Major -lt 6) {
+                Set-ItResult -Skipped -Because "PowerShell 5.1 wrapper handles PersonalAccessToken separately."
+                return
+            }
+
+            (Get-Command -Name Invoke-WebRequest).Parameters.Keys | Should -Contain "PersonalAccessToken"
+        }
+
         It "omits TimeoutSec from Invoke-WebRequest when TimeoutSec is 0" {
             $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -TimeoutSec 0 -ErrorAction Stop
 


### PR DESCRIPTION
## Summary
- fix PowerShell 6+ `-PersonalAccessToken` requests by accepting the module parameter in the private web-request wrapper
- forward the token as an `Authorization: Bearer` header, matching the JiraPS session-auth pattern
- add regression coverage for `Invoke-Method` token forwarding and the PS6+ wrapper signature

## Attribution
This PR carries forward the original bug report and fix proposal from @sebmaurer in #208 and #209.
The original PR is not mergeable as-is because it was opened from an old fork `master` and includes years of unrelated history, so this branch keeps the fix focused while preserving Sebastian's credit in the changelog and PR context.

## Context
This is a focused replacement for #209.
It closes #208.

## Validation
- `Invoke-Pester -Path 'Tests/Functions/Invoke-Method.Tests.ps1'`
- `Invoke-Build -Task Build, Test`

Closes #208
Supersedes #209
