### PR TITLE
Fix CQL labels with hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 
 ### Fixed
@@ -210,6 +211,7 @@ No changelog available for version `1.0` of ConfluencePS. `1.0` was created in l
 [@colhal]: https://github.com/colhal
 [@Dejulia489]: https://github.com/Dejulia489
 [@ebekker]: https://github.com/ebekker
+[@ehrenfeu]: https://github.com/ehrenfeu
 [@FelixMelchert]: https://github.com/FelixMelchert
 [@jkknorr]: https://github.com/jkknorr
 [@JohnAdders]: https://github.com/JohnAdders

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -142,7 +142,7 @@
                 $iwParameters["Uri"] = $resourceApi -f "/search"
 
                 $CQLparameters = @("type=page")
-                $Label | ForEach-Object { $CQLparameters += "label=$_" }
+                $Label | ForEach-Object { $CQLparameters += "label=`"$_`"" }
                 if ($SpaceKey) { $CQLparameters += "space=$SpaceKey" }
                 $iwParameters["GetParameters"]["cql"] = ($CQLparameters -join " AND ")
 

--- a/Tests/Functions/Get-Page.Tests.ps1
+++ b/Tests/Functions/Get-Page.Tests.ps1
@@ -25,23 +25,29 @@ InModuleScope ConfluencePS {
             }
         }
 
-        It "builds one label clause per label value for byLabel queries" {
+        It "builds one quoted label clause per label value for byLabel queries" {
             $null = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label @("labelA", "labelB")
 
             $script:lastUri | Should -Be "https://example.com/wiki/rest/api/content/search"
-            $script:lastCql | Should -Be "type=page AND label=labelA AND label=labelB"
+            $script:lastCql | Should -Be 'type=page AND label="labelA" AND label="labelB"'
         }
 
-        It "builds one label clause for a single byLabel value" {
+        It "builds one quoted label clause for a single byLabel value" {
             $null = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label @("labelA")
 
-            $script:lastCql | Should -Be "type=page AND label=labelA"
+            $script:lastCql | Should -Be 'type=page AND label="labelA"'
+        }
+
+        It "quotes hyphenated label values in byLabel queries" {
+            $null = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label "noarchive-single"
+
+            $script:lastCql | Should -Be 'type=page AND label="noarchive-single"'
         }
 
         It "appends space filtering to multi-label byLabel queries" {
             $null = Get-Page -ApiUri "https://example.com/wiki/rest/api" -SpaceKey "HOTH" -Label @("labelA", "labelB")
 
-            $script:lastCql | Should -Be "type=page AND label=labelA AND label=labelB AND space=HOTH"
+            $script:lastCql | Should -Be 'type=page AND label="labelA" AND label="labelB" AND space=HOTH'
         }
 
         It "prefixes byQuery CQL with type=page without pre-encoding" {


### PR DESCRIPTION
## Original contributor

This PR ports the still-relevant fix from #185 by @ehrenfeu / Niko Ehrenfeuchter onto current master. The original PR branch is stale/conflicting and includes unrelated historical drift, so this replacement PR keeps the actual bug fix while preserving contributor credit.

## Summary
- quote label values when building CQL for Get-ConfluencePage -Label
- add regression coverage for hyphenated labels and multi-label queries
- add a changelog entry crediting #185 and @ehrenfeu

## Context
Closes #175.
Supersedes #185.
Original contribution: #185 by @ehrenfeu.

## Validation
- Invoke-Pester -Path 'Tests/Functions/Get-Page.Tests.ps1'
- Invoke-Build -Task Lint
- Invoke-Build -Task Build, Test