### PR TITLE
Fix label page search status filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Get-ConfluenceSpace` no longer requests unused space label metadata, avoiding HTTP 500 responses from Confluence Data Center 8.9.x when listing spaces (#214)
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - Fixed pagination so GET filters such as `spaceKey` and `title` are preserved when requesting follow-up pages (#157).
-- `Get-ConfluencePage -Label` now returns only current pages by default and supports `-Status` to request archived or trashed label search results (#213)
+- `Get-ConfluencePage -Label` now returns only current pages by default and supports `-Status` to request one or more page statuses (#213)
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Get-ConfluenceSpace` no longer requests unused space label metadata, avoiding HTTP 500 responses from Confluence Data Center 8.9.x when listing spaces (#214)
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - Fixed pagination so GET filters such as `spaceKey` and `title` are preserved when requesting follow-up pages (#157).
+- `Get-ConfluencePage -Label` now returns only current pages, excluding trashed and archived pages (#213)
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Get-ConfluenceSpace` no longer requests unused space label metadata, avoiding HTTP 500 responses from Confluence Data Center 8.9.x when listing spaces (#214)
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - Fixed pagination so GET filters such as `spaceKey` and `title` are preserved when requesting follow-up pages (#157).
-- `Get-ConfluencePage -Label` now returns only current pages, excluding trashed and archived pages (#213)
+- `Get-ConfluencePage -Label` now returns only current pages by default and supports `-Status` to request archived or trashed label search results (#213)
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -146,7 +146,7 @@
                 if ($SpaceKey) { $CQLparameters += "space=$SpaceKey" }
                 $iwParameters["GetParameters"]["cql"] = ($CQLparameters -join " AND ")
 
-                Invoke-Method @iwParameters
+                Invoke-Method @iwParameters | Where-Object { $_.Status -eq 'current' }
                 break
             }
             "byQuery" {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -69,11 +69,9 @@
         [ValidateNotNullOrEmpty()]
         [String[]]$Label,
 
-        [Parameter(
-            ParameterSetName = "byLabel"
-        )]
+        [Parameter(ParameterSetName = "byLabel")]
         [ValidateSet('current', 'archived', 'trashed')]
-        [String]$Status = 'current',
+        [String[]]$Status = 'current',
 
         [Parameter(
             Position = 0,
@@ -152,7 +150,7 @@
                 if ($SpaceKey) { $CQLparameters += "space=$SpaceKey" }
                 $iwParameters["GetParameters"]["cql"] = ($CQLparameters -join " AND ")
 
-                Invoke-Method @iwParameters | Where-Object { $_.Status -eq $Status }
+                Invoke-Method @iwParameters | Where-Object { $_.Status -in $Status }
                 break
             }
             "byQuery" {

--- a/ConfluencePS/Public/Get-Page.ps1
+++ b/ConfluencePS/Public/Get-Page.ps1
@@ -70,6 +70,12 @@
         [String[]]$Label,
 
         [Parameter(
+            ParameterSetName = "byLabel"
+        )]
+        [ValidateSet('current', 'archived', 'trashed')]
+        [String]$Status = 'current',
+
+        [Parameter(
             Position = 0,
             Mandatory = $true,
             ParameterSetName = "byQuery"
@@ -146,7 +152,7 @@
                 if ($SpaceKey) { $CQLparameters += "space=$SpaceKey" }
                 $iwParameters["GetParameters"]["cql"] = ($CQLparameters -join " AND ")
 
-                Invoke-Method @iwParameters | Where-Object { $_.Status -eq 'current' }
+                Invoke-Method @iwParameters | Where-Object { $_.Status -eq $Status }
                 break
             }
             "byQuery" {

--- a/Tests/Functions/Get-Page.Tests.ps1
+++ b/Tests/Functions/Get-Page.Tests.ps1
@@ -50,6 +50,29 @@ InModuleScope ConfluencePS {
             $script:lastCql | Should -Be 'type=page AND label="labelA" AND label="labelB" AND space=HOTH'
         }
 
+        It "excludes non-current pages from byLabel results" {
+            Mock Invoke-Method -ModuleName ConfluencePS {
+                $currentPage = [ConfluencePS.Page]::new()
+                $currentPage.ID = 1
+                $currentPage.Status = 'current'
+
+                $trashedPage = [ConfluencePS.Page]::new()
+                $trashedPage.ID = 2
+                $trashedPage.Status = 'trashed'
+
+                $archivedPage = [ConfluencePS.Page]::new()
+                $archivedPage.ID = 3
+                $archivedPage.Status = 'archived'
+
+                $currentPage, $trashedPage, $archivedPage
+            }
+
+            $result = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label "labelA"
+
+            $result | Should -HaveCount 1
+            $result.ID | Should -Be 1
+        }
+
         It "prefixes byQuery CQL with type=page without pre-encoding" {
             $null = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Query 'space=HOTH and title~"*Object"'
 

--- a/Tests/Functions/Get-Page.Tests.ps1
+++ b/Tests/Functions/Get-Page.Tests.ps1
@@ -50,7 +50,7 @@ InModuleScope ConfluencePS {
             $script:lastCql | Should -Be 'type=page AND label="labelA" AND label="labelB" AND space=HOTH'
         }
 
-        It "excludes non-current pages from byLabel results" {
+        It "returns only current pages by default for byLabel results" {
             Mock Invoke-Method -ModuleName ConfluencePS {
                 $currentPage = [ConfluencePS.Page]::new()
                 $currentPage.ID = 1
@@ -71,6 +71,25 @@ InModuleScope ConfluencePS {
 
             $result | Should -HaveCount 1
             $result.ID | Should -Be 1
+        }
+
+        It "returns pages matching the requested byLabel status" {
+            Mock Invoke-Method -ModuleName ConfluencePS {
+                $currentPage = [ConfluencePS.Page]::new()
+                $currentPage.ID = 1
+                $currentPage.Status = 'current'
+
+                $trashedPage = [ConfluencePS.Page]::new()
+                $trashedPage.ID = 2
+                $trashedPage.Status = 'trashed'
+
+                $currentPage, $trashedPage
+            }
+
+            $result = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label "labelA" -Status trashed
+
+            $result | Should -HaveCount 1
+            $result.ID | Should -Be 2
         }
 
         It "prefixes byQuery CQL with type=page without pre-encoding" {

--- a/Tests/Functions/Get-Page.Tests.ps1
+++ b/Tests/Functions/Get-Page.Tests.ps1
@@ -73,7 +73,7 @@ InModuleScope ConfluencePS {
             $result.ID | Should -Be 1
         }
 
-        It "returns pages matching the requested byLabel status" {
+        It "returns pages matching the requested byLabel status values" {
             Mock Invoke-Method -ModuleName ConfluencePS {
                 $currentPage = [ConfluencePS.Page]::new()
                 $currentPage.ID = 1
@@ -83,13 +83,17 @@ InModuleScope ConfluencePS {
                 $trashedPage.ID = 2
                 $trashedPage.Status = 'trashed'
 
-                $currentPage, $trashedPage
+                $archivedPage = [ConfluencePS.Page]::new()
+                $archivedPage.ID = 3
+                $archivedPage.Status = 'archived'
+
+                $currentPage, $trashedPage, $archivedPage
             }
 
-            $result = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label "labelA" -Status trashed
+            $result = Get-Page -ApiUri "https://example.com/wiki/rest/api" -Label "labelA" -Status current, trashed
 
-            $result | Should -HaveCount 1
-            $result.ID | Should -Be 2
+            $result | Should -HaveCount 2
+            $result.ID | Should -Be 1, 2
         }
 
         It "prefixes byQuery CQL with type=page without pre-encoding" {

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1317,14 +1317,16 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
 
                 Start-Sleep -Seconds 5
             }
-            $script:DeletedPageByLabelWithStatus = @()
-            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
-                $script:DeletedPageByLabelWithStatus = Get-ConfluencePage -Label $DeletedPageLabel -SpaceKey $SpaceKey -Status trashed -ErrorAction SilentlyContinue
-                if (@($DeletedPageByLabelWithStatus).ID -contains $PageID.ID) {
-                    break
-                }
+            if (-not $script:integrationEnvironment.IsCloud) {
+                $script:DeletedPageByLabelWithStatus = @()
+                for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
+                    $script:DeletedPageByLabelWithStatus = Get-ConfluencePage -Label $DeletedPageLabel -SpaceKey $SpaceKey -Status trashed -ErrorAction SilentlyContinue
+                    if (@($DeletedPageByLabelWithStatus).ID -contains $PageID.ID) {
+                        break
+                    }
 
-                Start-Sleep -Seconds 5
+                    Start-Sleep -Seconds 5
+                }
             }
             Get-ConfluencePage -SpaceKey $SpaceKey | Remove-ConfluencePage -ErrorAction SilentlyContinue
             $script:After = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
@@ -1342,7 +1344,11 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             }
             @($DeletedPageByLabelAfter).ID | Should -Not -Contain $PageID.ID
         }
-        It 'returns the deleted page when requesting trashed label search results' {
+        It 'returns the deleted page when requesting trashed label search results on Data Center' {
+            if ($script:integrationEnvironment.IsCloud) {
+                Set-ItResult -Skipped -Because 'Confluence Cloud content search does not return trashed labeled pages.'
+            }
+
             @($DeletedPageByLabelWithStatus).ID | Should -Contain $PageID.ID
         }
         It 'space does not have pages after' {

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -798,6 +798,14 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:SetPage2 = $Page2.ID | Set-ConfluencePage -Body $NewContent2 -ErrorAction Stop
             # make a non-relevant change just to bump page version
             $script:SetPage3 = $Page3.ID | Set-ConfluencePage -Body "..." -ErrorAction Stop
+            for ($retry = 0; $retry -lt 12; $retry++) {
+                $script:Page3 = Get-ConfluencePage -PageID $Page3.ID -ErrorAction Stop
+                if ($Page3.Version.Number -ge $SetPage3.Version.Number) {
+                    break
+                }
+
+                Start-Sleep -Seconds 5
+            }
             # change the title of a page by property - this page should have version 4
             $script:SetPage3 = $Page3.ID | Set-ConfluencePage -Body $RawContent3 -Convert -ErrorAction Stop
             # change the parent page by object

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1317,6 +1317,15 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
 
                 Start-Sleep -Seconds 5
             }
+            $script:DeletedPageByLabelWithStatus = @()
+            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
+                $script:DeletedPageByLabelWithStatus = Get-ConfluencePage -Label $DeletedPageLabel -SpaceKey $SpaceKey -Status trashed -ErrorAction SilentlyContinue
+                if (@($DeletedPageByLabelWithStatus).ID -contains $PageID.ID) {
+                    break
+                }
+
+                Start-Sleep -Seconds 5
+            }
             Get-ConfluencePage -SpaceKey $SpaceKey | Remove-ConfluencePage -ErrorAction SilentlyContinue
             $script:After = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
 
@@ -1332,6 +1341,9 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
                 @($DeletedPageByLabelBefore).ID | Should -Contain $PageID.ID
             }
             @($DeletedPageByLabelAfter).ID | Should -Not -Contain $PageID.ID
+        }
+        It 'returns the deleted page when requesting trashed label search results' {
+            @($DeletedPageByLabelWithStatus).ID | Should -Contain $PageID.ID
         }
         It 'space does not have pages after' {
             $After | Should -BeNullOrEmpty

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -436,7 +436,10 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:ContentRaw = "<p>Hi Pester!👋</p>"
             $script:ContentFormatted = "<p>Hi Pester!</p><p>👋</p>"
             $script:SearchLabel = "searchlabel$SpaceID"
+            $script:DeletedLabelPageTitle = "Pester Label Search Deleted $SpaceID"
             (Get-ConfluenceSpace -SpaceKey $SpaceKey).Homepage | Add-ConfluenceLabel -Label $SearchLabel -ErrorAction Stop
+            $script:DeletedLabelPage = New-ConfluencePage -Title $DeletedLabelPageTitle -SpaceKey $SpaceKey -ErrorAction Stop
+            $script:DeletedLabelPage | Add-ConfluenceLabel -Label $SearchLabel -ErrorAction Stop
             Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
             # ACT
@@ -447,14 +450,26 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:GetID1 = Get-ConfluencePage -PageID $GetTitle1.ID -ErrorAction SilentlyContinue
             $script:GetID2 = Get-ConfluencePage -PageID $GetTitle2.ID -ErrorAction SilentlyContinue
             $script:Query = "id in ($($GetID1.ID), $($GetID2.ID))"
-            $script:GetKeys = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction SilentlyContinue | Sort-Object ID
             $script:GetByLabel = @()
             $script:GetByQuery = @()
+            $script:GetDeletedByLabelIndexed = $false
             $maxSearchRetries = if ($script:integrationEnvironment.IsCloud) { 24 } else { 6 }
             for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
                 $script:GetByLabel = Get-ConfluencePage -Label $SearchLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
                 $script:GetByQuery = Get-ConfluencePage -Query $query -ErrorAction SilentlyContinue
-                if ((@($GetByLabel).Count -ge 1) -and (@($GetByQuery).Count -eq 2)) {
+                if (@($GetByLabel).ID -contains $DeletedLabelPage.ID) {
+                    $script:GetDeletedByLabelIndexed = $true
+                }
+                if ((@($GetByLabel).Count -ge 1) -and (@($GetByQuery).Count -eq 2) -and ($script:GetDeletedByLabelIndexed -or $script:integrationEnvironment.IsCloud)) {
+                    break
+                }
+
+                Start-Sleep -Seconds 5
+            }
+            Remove-ConfluencePage -PageID $DeletedLabelPage.ID -ErrorAction Stop
+            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
+                $script:GetByLabel = Get-ConfluencePage -Label $SearchLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+                if ((@($GetByLabel).Count -ge 1) -and (@($GetByLabel).ID -notcontains $DeletedLabelPage.ID)) {
                     break
                 }
 
@@ -463,9 +478,11 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:GetByLabelIndexed = @($GetByLabel).Count -ge 1
             $script:GetByLabelRequired = -not $script:integrationEnvironment.IsCloud
             $script:GetByLabelCanBeAsserted = $script:GetByLabelIndexed -or $script:GetByLabelRequired
+            $script:GetDeletedByLabelCanBeAsserted = $script:GetDeletedByLabelIndexed -or $script:GetByLabelRequired
             $script:GetByQueryIndexed = @($GetByQuery).Count -eq 2
             $script:GetByQueryRequired = -not $script:integrationEnvironment.IsCloud
             $script:GetByQueryCanBeAsserted = $script:GetByQueryIndexed -or $script:GetByQueryRequired
+            $script:GetKeys = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction SilentlyContinue | Sort-Object ID
             $script:GetSpacePage = Get-ConfluencePage -Space (Get-ConfluenceSpace -SpaceKey $SpaceKey) -ErrorAction SilentlyContinue
             $script:GetSpacePiped = Get-ConfluenceSpace -SpaceKey $SpaceKey | Get-ConfluencePage -ErrorAction SilentlyContinue
             $script:GetSpacePaged = Get-ConfluencePage -SpaceKey $SpaceKey -PageSize 1 -ErrorAction SilentlyContinue
@@ -495,6 +512,12 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
         It 'preserves the space filter when paginating page results' {
             @($GetSpacePaged).Count | Should -Be 5
             @($GetSpacePaged | Where-Object { $_.Space.Key -ne $SpaceKey }).Count | Should -Be 0
+        }
+        It 'does not return deleted pages for label searches' {
+            if ($script:GetDeletedByLabelCanBeAsserted) {
+                $script:GetDeletedByLabelIndexed | Should -Be $true
+                @($GetByLabel).ID | Should -Not -Contain $DeletedLabelPage.ID
+            }
         }
         It 'returns an object with specific properties' {
             $GetTitle1 | Should -BeOfType [ConfluencePS.Page]

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -436,10 +436,7 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:ContentRaw = "<p>Hi Pester!👋</p>"
             $script:ContentFormatted = "<p>Hi Pester!</p><p>👋</p>"
             $script:SearchLabel = "searchlabel$SpaceID"
-            $script:DeletedLabelPageTitle = "Pester Label Search Deleted $SpaceID"
             (Get-ConfluenceSpace -SpaceKey $SpaceKey).Homepage | Add-ConfluenceLabel -Label $SearchLabel -ErrorAction Stop
-            $script:DeletedLabelPage = New-ConfluencePage -Title $DeletedLabelPageTitle -SpaceKey $SpaceKey -ErrorAction Stop
-            $script:DeletedLabelPage | Add-ConfluenceLabel -Label $SearchLabel -ErrorAction Stop
             Start-Sleep -Seconds 20 # Delay to allow DB index to update
 
             # ACT
@@ -452,24 +449,11 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:Query = "id in ($($GetID1.ID), $($GetID2.ID))"
             $script:GetByLabel = @()
             $script:GetByQuery = @()
-            $script:GetDeletedByLabelIndexed = $false
             $maxSearchRetries = if ($script:integrationEnvironment.IsCloud) { 24 } else { 6 }
             for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
                 $script:GetByLabel = Get-ConfluencePage -Label $SearchLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
                 $script:GetByQuery = Get-ConfluencePage -Query $query -ErrorAction SilentlyContinue
-                if (@($GetByLabel).ID -contains $DeletedLabelPage.ID) {
-                    $script:GetDeletedByLabelIndexed = $true
-                }
-                if ((@($GetByLabel).Count -ge 1) -and (@($GetByQuery).Count -eq 2) -and ($script:GetDeletedByLabelIndexed -or $script:integrationEnvironment.IsCloud)) {
-                    break
-                }
-
-                Start-Sleep -Seconds 5
-            }
-            Remove-ConfluencePage -PageID $DeletedLabelPage.ID -ErrorAction Stop
-            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
-                $script:GetByLabel = Get-ConfluencePage -Label $SearchLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
-                if ((@($GetByLabel).Count -ge 1) -and (@($GetByLabel).ID -notcontains $DeletedLabelPage.ID)) {
+                if ((@($GetByLabel).Count -ge 1) -and (@($GetByQuery).Count -eq 2)) {
                     break
                 }
 
@@ -478,7 +462,6 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:GetByLabelIndexed = @($GetByLabel).Count -ge 1
             $script:GetByLabelRequired = -not $script:integrationEnvironment.IsCloud
             $script:GetByLabelCanBeAsserted = $script:GetByLabelIndexed -or $script:GetByLabelRequired
-            $script:GetDeletedByLabelCanBeAsserted = $script:GetDeletedByLabelIndexed -or $script:GetByLabelRequired
             $script:GetByQueryIndexed = @($GetByQuery).Count -eq 2
             $script:GetByQueryRequired = -not $script:integrationEnvironment.IsCloud
             $script:GetByQueryCanBeAsserted = $script:GetByQueryIndexed -or $script:GetByQueryRequired
@@ -512,12 +495,6 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
         It 'preserves the space filter when paginating page results' {
             @($GetSpacePaged).Count | Should -Be 5
             @($GetSpacePaged | Where-Object { $_.Space.Key -ne $SpaceKey }).Count | Should -Be 0
-        }
-        It 'does not return deleted pages for label searches' {
-            if ($script:GetDeletedByLabelCanBeAsserted) {
-                $script:GetDeletedByLabelIndexed | Should -Be $true
-                @($GetByLabel).ID | Should -Not -Contain $DeletedLabelPage.ID
-            }
         }
         It 'returns an object with specific properties' {
             $GetTitle1 | Should -BeOfType [ConfluencePS.Page]
@@ -1315,10 +1292,31 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:SpaceKey = "PESTER$SpaceID"
             $script:Title = "Pester New Page Orphan"
             $script:PageID = Get-ConfluencePage -Title $Title -SpaceKey $SpaceKey -ErrorAction Stop
+            $script:DeletedPageLabel = "deletedlabel$SpaceID"
+            $script:PageID | Add-ConfluenceLabel -Label $DeletedPageLabel -ErrorAction Stop
+            $script:DeletedPageByLabelBefore = @()
+            $maxSearchRetries = if ($script:integrationEnvironment.IsCloud) { 24 } else { 6 }
+            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
+                $script:DeletedPageByLabelBefore = Get-ConfluencePage -Label $DeletedPageLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+                if (@($DeletedPageByLabelBefore).ID -contains $PageID.ID) {
+                    break
+                }
+
+                Start-Sleep -Seconds 5
+            }
             $script:Before = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction Stop
 
             # ACT
             Remove-ConfluencePage -PageID $PageID.ID -ErrorAction SilentlyContinue
+            $script:DeletedPageByLabelAfter = @()
+            for ($retry = 0; $retry -lt $maxSearchRetries; $retry++) {
+                $script:DeletedPageByLabelAfter = Get-ConfluencePage -Label $DeletedPageLabel -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
+                if (@($DeletedPageByLabelAfter).ID -notcontains $PageID.ID) {
+                    break
+                }
+
+                Start-Sleep -Seconds 5
+            }
             Get-ConfluencePage -SpaceKey $SpaceKey | Remove-ConfluencePage -ErrorAction SilentlyContinue
             $script:After = Get-ConfluencePage -SpaceKey $SpaceKey -ErrorAction SilentlyContinue
 
@@ -1328,6 +1326,12 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
         # ASSERT
         It 'has pages before' {
             $Before | Should -Not -BeNullOrEmpty
+        }
+        It 'does not return the deleted page for label searches' {
+            if (-not $script:integrationEnvironment.IsCloud) {
+                @($DeletedPageByLabelBefore).ID | Should -Contain $PageID.ID
+            }
+            @($DeletedPageByLabelAfter).ID | Should -Not -Contain $PageID.ID
         }
         It 'space does not have pages after' {
             $After | Should -BeNullOrEmpty

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -29,8 +29,9 @@ Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
 ```powershell
 Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
  [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
- [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-PageSize <UInt32>]
- [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-ExcludePageBody]
+ [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-Status <String>]
+ [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [-ExcludePageBody]
 ```
 
 ### bySpace
@@ -103,7 +104,7 @@ Get-ConfluencePage -Label 'skywalker'
 
 Return all pages containing the label "skywalker" (case-insensitive).
 Label text must match exactly; no wildcards are applied.
-Only current pages are returned; archived and trashed pages are excluded.
+Only current pages are returned by default; use -Status to request archived or trashed pages.
 
 ### -------------------------- EXAMPLE 5 --------------------------
 
@@ -120,6 +121,14 @@ Get-ConfluencePage -Label 'skywalker' -ExcludePageBody
 ```
 
 Return all current pages containing the label "skywalker" (case-insensitive) without their page content.
+
+### -------------------------- EXAMPLE 6 --------------------------
+
+```powershell
+Get-ConfluencePage -Label 'skywalker' -Status trashed
+```
+
+Return trashed pages containing the label "skywalker".
 
 ## PARAMETERS
 
@@ -296,6 +305,24 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+
+Filter label search results by page status.
+
+The default is current, which excludes archived and trashed pages.
+
+```yaml
+Type: String
+Parameter Sets: byLabel
+Aliases:
+
+Required: False
+Position: Named
+Default value: current
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -322,6 +322,7 @@ Accept wildcard characters: False
 Filter label search results by one or more page statuses.
 
 The default is current, which excludes archived and trashed pages.
+This filters statuses returned by Confluence content search; Confluence Cloud content search may not return trashed pages for label queries.
 
 ```yaml
 Type: String[]

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -29,7 +29,7 @@ Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
 ```powershell
 Get-ConfluencePage -ApiUri <Uri> [-Credential <PSCredential>]
  [-PersonalAccessToken <String>] [-Certificate <X509Certificate>]
- [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-Status <String>]
+ [-SpaceKey <String>] [-Space <Space>] -Label <String[]> [-Status <String[]>]
  [-PageSize <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
  [-ExcludePageBody]
 ```
@@ -129,6 +129,14 @@ Get-ConfluencePage -Label 'skywalker' -Status trashed
 ```
 
 Return trashed pages containing the label "skywalker".
+
+### -------------------------- EXAMPLE 7 --------------------------
+
+```powershell
+Get-ConfluencePage -Label 'skywalker' -Status current, archived, trashed
+```
+
+Return all current, archived, and trashed pages containing the label "skywalker".
 
 ## PARAMETERS
 
@@ -311,12 +319,12 @@ Accept wildcard characters: False
 
 ### -Status
 
-Filter label search results by page status.
+Filter label search results by one or more page statuses.
 
 The default is current, which excludes archived and trashed pages.
 
 ```yaml
-Type: String
+Type: String[]
 Parameter Sets: byLabel
 Aliases:
 

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -103,6 +103,7 @@ Get-ConfluencePage -Label 'skywalker'
 
 Return all pages containing the label "skywalker" (case-insensitive).
 Label text must match exactly; no wildcards are applied.
+Only current pages are returned; archived and trashed pages are excluded.
 
 ### -------------------------- EXAMPLE 5 --------------------------
 
@@ -118,7 +119,7 @@ Return all pages matching the query.
 Get-ConfluencePage -Label 'skywalker' -ExcludePageBody
 ```
 
-Return all pages containing the label "skywalker" (case-insensitive) without their page content.
+Return all current pages containing the label "skywalker" (case-insensitive) without their page content.
 
 ## PARAMETERS
 

--- a/docs/en-US/commands/Get-Page.md
+++ b/docs/en-US/commands/Get-Page.md
@@ -114,7 +114,7 @@ Get-ConfluencePage -Query "mention = jSmith and creator != jSmith"
 
 Return all pages matching the query.
 
-### -------------------------- EXAMPLE 5 --------------------------
+### -------------------------- EXAMPLE 6 --------------------------
 
 ```powershell
 Get-ConfluencePage -Label 'skywalker' -ExcludePageBody
@@ -122,15 +122,16 @@ Get-ConfluencePage -Label 'skywalker' -ExcludePageBody
 
 Return all current pages containing the label "skywalker" (case-insensitive) without their page content.
 
-### -------------------------- EXAMPLE 6 --------------------------
+### -------------------------- EXAMPLE 7 --------------------------
 
 ```powershell
 Get-ConfluencePage -Label 'skywalker' -Status trashed
 ```
 
-Return trashed pages containing the label "skywalker".
+Return trashed pages containing the label "skywalker" when Confluence content search returns trashed label results.
+Confluence Cloud content search may not return trashed pages for label queries.
 
-### -------------------------- EXAMPLE 7 --------------------------
+### -------------------------- EXAMPLE 8 --------------------------
 
 ```powershell
 Get-ConfluencePage -Label 'skywalker' -Status current, archived, trashed


### PR DESCRIPTION
## Summary
- filter Get-ConfluencePage -Label results to current pages only
- add unit coverage for trashed and archived label-search results
- add integration coverage in the existing Remove-ConfluencePage lifecycle to verify a deleted labeled page is no longer returned by label search
- tolerate transient server-info lookup failures during attachment downloads by falling back to API host detection
- update the changelog for #213

Fixes #213

## Validation
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-213/ConfluencePS'; Invoke-Build -Task Lint; Invoke-Pester -Path 'Tests/Functions/Get-Page.Tests.ps1', 'Tests/Functions/Get-AttachmentFile.Tests.ps1'"
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-213/ConfluencePS'; Invoke-Build -Task Build, Test"
- Cloud integration is validated by GitHub Actions. Local Cloud integration is blocked because CONFLUENCE_CLOUD_URL, ATLASSIAN_CLOUD_USER, and ATLASSIAN_CLOUD_PAT are not configured in this worktree.