### PR TITLE
Document Confluence Cloud authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Documented how to authenticate to Confluence Cloud with an Atlassian account email address and API token (#203).
 - Migrated `Tools/setup.ps1` and `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards` bootstrap/update commands with deterministic standards-version resolution from `Tools/build.requirements.psd1`.
 - Replaced legacy PSDepend hashtable dependencies with pinned array requirements and aligned workflow setup action usage to the pinned standards action release.
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Documented how to authenticate to Confluence Cloud with an Atlassian account email address and API token (#203).
+- Documented how to authenticate to Confluence Cloud with an Atlassian account email address and API token, including a dedicated authentication about topic (#203, #248, [@lipkau]).
 - Migrated `Tools/setup.ps1` and `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards` bootstrap/update commands with deterministic standards-version resolution from `Tools/build.requirements.psd1`.
 - Replaced legacy PSDepend hashtable dependencies with pinned array requirements and aligned workflow setup action usage to the pinned standards action release.
 - `Set-ConfluencePage` now forwards `Version.Message` for `-InputObject` / pipeline updates when provided (#207, #231, [@JoseAPortilloJSC])

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Update-Module ConfluencePS
 
 # To use each session:
 Import-Module ConfluencePS
-Set-ConfluenceInfo -BaseURI 'https://YourCloudWiki.atlassian.net/wiki' -PromptCredentials
+$credential = Get-Credential -UserName 'me@example.com'
+Set-ConfluenceInfo -BaseURI 'https://YourCloudWiki.atlassian.net/wiki' -Credential $credential
 ```
 
 ### Usage
@@ -47,11 +48,13 @@ You can find the full documentation on our [homepage](https://atlassianps.org/do
 ```powershell
 # Review the help at any time!
 Get-Help about_ConfluencePS
+Get-Help about_ConfluencePS_Authentication
 Get-Command -Module ConfluencePS
 Get-Help Get-ConfluencePage -Full   # or any other command
 ```
 
 For first steps to get up and running, check out the [Getting Started](https://atlassianps.org/docs/ConfluencePS/#getting-started) page.
+For Cloud, Data Center, Server, and anonymous authentication examples, see the [authentication guide](https://atlassianps.org/docs/ConfluencePS/about/authentication.html).
 
 ### Contribute
 

--- a/docs/en-US/about_ConfluencePS.md
+++ b/docs/en-US/about_ConfluencePS.md
@@ -36,11 +36,13 @@ method for Server installations in the future.
 
 ```powershell
 Import-Module ConfluencePS
-Set-ConfluenceInfo -BaseURI 'https://mywiki.company.com' -PromptCredentials
+$credential = Get-Credential -UserName 'me@example.com'
+Set-ConfluenceInfo -BaseURI 'https://yournamehere.atlassian.net/wiki' -Credential $credential
 ```
 
-Unless supplying the credentials (`-Credential $cred`), you will be
-prompted for a username/password to connect to your wiki instance.
+For Confluence Cloud, use your Atlassian account email address and an API token.
+For Confluence Data Center or Server, use the authentication method configured for your instance.
+See [about_ConfluencePS_Authentication](about/authentication.html) for Cloud, Data Center, Server, and anonymous authentication examples.
 
 `Set-ConfluenceInfo` sets defaults in your current session for common parameters
 `-ApiUri` and `-Credential`. This saves you from entering the info into each command,
@@ -134,6 +136,8 @@ Find us on GitHub or Slack, and let us know what you think.
 # SEE ALSO
 
 [Commands index](/docs/ConfluencePS/commands/)
+
+[Authentication guide](/docs/ConfluencePS/about/authentication.html)
 
 [Classes index](/docs/ConfluencePS/classes/)
 

--- a/docs/en-US/about_ConfluencePS_Authentication.md
+++ b/docs/en-US/about_ConfluencePS_Authentication.md
@@ -1,0 +1,109 @@
+---
+locale: en-US
+layout: documentation
+online version: https://atlassianps.org/docs/ConfluencePS/about/authentication.html
+Module Name: ConfluencePS
+permalink: /docs/ConfluencePS/about/authentication.html
+---
+# Authentication
+
+## about_ConfluencePS_Authentication
+
+# SHORT DESCRIPTION
+
+Configure authentication for ConfluencePS commands against Confluence Cloud, Data Center, or Server.
+
+# LONG DESCRIPTION
+
+ConfluencePS sends requests to Confluence's REST API.
+Most commands accept `-ApiUri`, `-Credential`, `-PersonalAccessToken`, or `-Certificate` directly.
+For repeated commands, use `Set-ConfluenceInfo` once per PowerShell session to set default connection and authentication parameters.
+
+The authentication method depends on where Confluence is hosted:
+
+- Confluence Cloud: Atlassian account email address plus an Atlassian API token through `-Credential`.
+- Confluence Data Center or Server: username/password through `-Credential`, or a personal access token through `-PersonalAccessToken` when your instance supports it.
+- Certificate-based authentication: use `-Certificate` on commands that expose it when your environment requires client certificates.
+
+## Confluence Cloud
+
+Confluence Cloud uses Atlassian account API tokens for scripts and automation.
+Create an API token at https://id.atlassian.com/manage-profile/security/api-tokens.
+Use your Atlassian account email address as the credential username and the API token as the credential password.
+
+Cloud site URLs must include `/wiki` when passed to `Set-ConfluenceInfo`.
+For example, use `https://yournamehere.atlassian.net/wiki`, not only `https://yournamehere.atlassian.net`.
+
+```powershell
+$credential = Get-Credential -UserName 'me@example.com'
+Set-ConfluenceInfo -BaseURI 'https://yournamehere.atlassian.net/wiki' -Credential $credential
+```
+
+When prompted, paste the Atlassian API token as the password.
+Do not use your Atlassian account password for Cloud authentication.
+
+For non-interactive scripts, create the `PSCredential` from a secret source such as an environment variable or a vault.
+
+```powershell
+$token = ConvertTo-SecureString -String $env:ATLASSIAN_CLOUD_API_TOKEN -AsPlainText -Force
+$credential = [PSCredential]::new($env:ATLASSIAN_CLOUD_EMAIL, $token)
+Set-ConfluenceInfo -BaseURI $env:CONFLUENCE_CLOUD_URL -Credential $credential
+```
+
+Store the full Cloud URL, including `/wiki`, in `CONFLUENCE_CLOUD_URL`.
+
+## Confluence Data Center and Server
+
+For Confluence Data Center or Server, use the authentication method configured for your instance.
+Username/password authentication uses the `-Credential` parameter.
+
+```powershell
+$credential = Get-Credential
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -Credential $credential
+```
+
+If your Confluence Data Center or Server instance supports personal access tokens, pass the token to `-PersonalAccessToken`.
+ConfluencePS sends this value as bearer-token authentication.
+
+```powershell
+$pat = Read-Host -Prompt 'Confluence personal access token'
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -PersonalAccessToken $pat
+```
+
+Atlassian API tokens for Cloud and personal access tokens for Data Center or Server are different credential types.
+For Cloud, use `-Credential` with your email address and API token.
+For Data Center or Server PATs, use `-PersonalAccessToken`.
+
+## Anonymous Access
+
+If your Confluence instance allows anonymous access, you can set only the base URI.
+Commands then run without credentials and can access only content available to anonymous users.
+
+```powershell
+Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com'
+```
+
+## Per-Command Overrides
+
+`Set-ConfluenceInfo` configures defaults for the current PowerShell session.
+You can still pass `-ApiUri`, `-Credential`, `-PersonalAccessToken`, or `-Certificate` to an individual command to override the defaults.
+
+```powershell
+Get-ConfluenceSpace -ApiUri 'https://otherwiki.example.com/rest/api' -Credential $otherCredential
+```
+
+## Security Notes
+
+Use HTTPS for authenticated connections.
+Avoid hardcoding passwords, API tokens, or personal access tokens in scripts.
+Prefer environment variables, secret-management modules, or CI/CD secret storage.
+
+# SEE ALSO
+
+[Set-ConfluenceInfo](/docs/ConfluencePS/commands/Set-Info/)
+
+[Get-ConfluenceServerInformation](/docs/ConfluencePS/commands/Get-ServerInformation/)
+
+[Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
+
+[Using personal access tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)

--- a/docs/en-US/commands/Set-Info.md
+++ b/docs/en-US/commands/Set-Info.md
@@ -202,4 +202,6 @@ https://yournamehere.atlassian.net/wiki.
 
 [ConfluencePS PR#59: Add proper Paging to Get functions](https://github.com/AtlassianPS/ConfluencePS/pull/59)
 
+[about_ConfluencePS_Authentication](/docs/ConfluencePS/about/authentication.html)
+
 [Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)

--- a/docs/en-US/commands/Set-Info.md
+++ b/docs/en-US/commands/Set-Info.md
@@ -28,8 +28,10 @@ URI/auth info to all other functions in the module (e.g. Get-ConfluenceSpace).
 These session defaults can be overwritten on any single command, but using
 Set-ConfluenceInfo avoids repetitively specifying -ApiUri and -Credential parameters.
 
-Confluence's REST API supports passing basic authentication in headers.
-(If you have a better suggestion for how to handle auth, please reach out on GitHub!)
+Confluence's REST API supports passing basic authentication in headers. For
+Confluence Cloud, use your Atlassian account email address as the username and
+an Atlassian API token as the password. Do not use your Atlassian account
+password for Cloud authentication.
 
 Unless allowing anonymous access to your instance, credentials are needed.
 
@@ -38,11 +40,13 @@ Unless allowing anonymous access to your instance, credentials are needed.
 ### -------------------------- EXAMPLE 1 --------------------------
 
 ```powershell
-Set-ConfluenceInfo -BaseURI 'https://yournamehere.atlassian.net/wiki' -PromptCredentials
+$Cred = Get-Credential -UserName 'me@example.com'
+Set-ConfluenceInfo -BaseURI 'https://yournamehere.atlassian.net/wiki' -Credential $Cred
 ```
 
-Declare the URI of your Confluence instance; be prompted for username and password.
-Note that Atlassian Cloud Confluence instances typically use the /wiki subdirectory.
+Declare the URI of your Confluence Cloud instance and authenticate with an
+Atlassian account email address and API token. When prompted, enter the API
+token as the password. Cloud instances use the /wiki subdirectory.
 
 ### -------------------------- EXAMPLE 2 --------------------------
 
@@ -69,8 +73,9 @@ $Cred = Get-Credential
 Set-ConfluenceInfo -BaseURI 'https://wiki.yourcompany.com' -Credential $Cred
 ```
 
-Declare the URI of your Confluence instance and the credentials (username and
-password).
+Declare the URI of your Confluence instance and the credentials. For Confluence
+Cloud, the credential username is your Atlassian account email address and the
+password is an Atlassian API token.
 
 ### -------------------------- EXAMPLE 5 --------------------------
 
@@ -103,7 +108,9 @@ Accept wildcard characters: False
 
 ### -Credential
 
-The username/password combo you use to log in to Confluence.
+The username/password combo used to authenticate to Confluence. For Confluence
+Cloud, use your Atlassian account email address as the username and an Atlassian
+API token as the password.
 
 ```yaml
 Type: PSCredential
@@ -119,7 +126,10 @@ Accept wildcard characters: False
 
 ### -PersonalAccessToken
 
-The PersonalAccessToken you created in your Confluence User Settings.
+The PersonalAccessToken you created in your Confluence User Settings. This is
+for Confluence Data Center and Server personal access tokens. For Confluence
+Cloud, use the -Credential parameter with your Atlassian account email address
+and an Atlassian API token.
 
 ```yaml
 Type: String
@@ -180,8 +190,16 @@ See related links for implementation discussion and details.
 
 (If you don't know exactly what this means, feel free to ignore it.)
 
+For Confluence Cloud authentication, create an API token at
+https://id.atlassian.com/manage-profile/security/api-tokens. Use your Atlassian
+account email address as the credential username and paste the API token as the
+credential password. The BaseURI must include /wiki, for example
+https://yournamehere.atlassian.net/wiki.
+
 ## RELATED LINKS
 
 [https://github.com/AtlassianPS/ConfluencePS](https://github.com/AtlassianPS/ConfluencePS)
 
 [ConfluencePS PR#59: Add proper Paging to Get functions](https://github.com/AtlassianPS/ConfluencePS/pull/59)
+
+[Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -34,3 +34,4 @@ The documentation pages use the source function names that back the exported com
 | `Set-ConfluencePage` | [Set-Page](/docs/ConfluencePS/commands/Set-Page/) |
 
 For module overview and setup, see [about_ConfluencePS](/docs/ConfluencePS/).
+For Cloud, Data Center, Server, and anonymous authentication examples, see [about_ConfluencePS_Authentication](/docs/ConfluencePS/about/authentication.html).


### PR DESCRIPTION
## Summary
- document Confluence Cloud authentication with Atlassian account email and API token
- clarify that Cloud uses /wiki in BaseURI and -Credential rather than -PersonalAccessToken
- add Atlassian API token documentation link and changelog entry

Closes #203

## Validation
- Invoke-Pester -Path 'Tests/Help.Tests.ps1' (0 failed, 2 skipped outside Release)
- Invoke-Build -Task Build, Test (164 passed)
- git diff --check