### PR TITLE
Fix pagination with GET parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
+- Fixed pagination so GET filters such as `spaceKey` and `title` are preserved when requesting follow-up pages (#157).
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -129,6 +129,10 @@
         if (($PSCmdlet.PagingParameters) -and ($PSCmdlet.PagingParameters.Skip)) {
             $GetParameters["start"] = $PSCmdlet.PagingParameters.Skip
         }
+        $paginationGetParameters = $null
+        if ($GetParameters) {
+            $paginationGetParameters = $GetParameters.Clone()
+        }
         # Append GET parameters to Uri, aka query Parameters
         if ($GetParameters -and ($Uri.Query -eq "")) {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Using `$GetParameters: $($GetParameters | Out-String)"
@@ -383,6 +387,17 @@
 
                                 $parameters = Copy-CommonParameter -InputObject $PSBoundParameters -AdditionalParameter @("Method", "Headers", "OutputType", "TimeoutSec")
                                 $parameters['Uri'] = "{0}{1}" -f $response._links.base, $response._links.next
+                                if ($paginationGetParameters) {
+                                    $nextUriBuilder = [System.UriBuilder]$parameters['Uri']
+                                    $nextQueryParameters = [System.Web.HttpUtility]::ParseQueryString($nextUriBuilder.Query)
+                                    foreach ($key in $paginationGetParameters.Keys) {
+                                        if ($nextQueryParameters.AllKeys -notcontains $key) {
+                                            $nextQueryParameters[[string]$key] = [string]$paginationGetParameters[$key]
+                                        }
+                                    }
+                                    $nextUriBuilder.Query = $nextQueryParameters.ToString()
+                                    $parameters['Uri'] = $nextUriBuilder.Uri
+                                }
 
                                 Write-Verbose "NEXT PAGE: $($parameters["Uri"])"
 

--- a/ConfluencePS/Public/Invoke-Method.ps1
+++ b/ConfluencePS/Public/Invoke-Method.ps1
@@ -388,6 +388,7 @@
                                 $parameters = Copy-CommonParameter -InputObject $PSBoundParameters -AdditionalParameter @("Method", "Headers", "OutputType", "TimeoutSec")
                                 $parameters['Uri'] = "{0}{1}" -f $response._links.base, $response._links.next
                                 if ($paginationGetParameters) {
+                                    $parameters['GetParameters'] = $paginationGetParameters
                                     $nextUriBuilder = [System.UriBuilder]$parameters['Uri']
                                     $nextQueryParameters = [System.Web.HttpUtility]::ParseQueryString($nextUriBuilder.Query)
                                     foreach ($key in $paginationGetParameters.Keys) {

--- a/Tests/Functions/Invoke-Method.Tests.ps1
+++ b/Tests/Functions/Invoke-Method.Tests.ps1
@@ -379,7 +379,12 @@ namespace ConfluencePS.Tests {
                     return New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":1}],"_links":{"base":"https://example.com","next":"/wiki/rest/api/content?limit=20&start=20"}}'
                 }
 
-                New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":2}]}'
+                if ($script:invokeCount -eq 1) {
+                    $script:invokeCount++
+                    return New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":2}],"_links":{"base":"https://example.com","next":"/wiki/rest/api/content?limit=20&start=40"}}'
+                }
+
+                New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":3}]}'
             }
 
             $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -GetParameters @{
@@ -387,13 +392,15 @@ namespace ConfluencePS.Tests {
                 title    = "my Page"
             } -ErrorAction Stop
 
-            $script:requestUris | Should -HaveCount 2
-            $nextUri = [uri]$script:requestUris[1]
-            $nextQueryParameters = [System.Web.HttpUtility]::ParseQueryString($nextUri.Query)
-            $nextQueryParameters["spaceKey"] | Should -Be "Foo"
-            $nextQueryParameters["title"] | Should -Be "my Page"
-            $nextQueryParameters["limit"] | Should -Be "20"
-            $nextQueryParameters["start"] | Should -Be "20"
+            $script:requestUris | Should -HaveCount 3
+            foreach ($nextUri in @([uri]$script:requestUris[1], [uri]$script:requestUris[2])) {
+                $nextQueryParameters = [System.Web.HttpUtility]::ParseQueryString($nextUri.Query)
+                $nextQueryParameters["spaceKey"] | Should -Be "Foo"
+                $nextQueryParameters["title"] | Should -Be "my Page"
+                $nextQueryParameters["limit"] | Should -Be "20"
+            }
+            ([System.Web.HttpUtility]::ParseQueryString(([uri]$script:requestUris[1]).Query))["start"] | Should -Be "20"
+            ([System.Web.HttpUtility]::ParseQueryString(([uri]$script:requestUris[2]).Query))["start"] | Should -Be "40"
         }
 
         It "surfaces JSON errorMessages from HTTP error responses" {

--- a/Tests/Functions/Invoke-Method.Tests.ps1
+++ b/Tests/Functions/Invoke-Method.Tests.ps1
@@ -366,6 +366,36 @@ namespace ConfluencePS.Tests {
             $script:requestUris[1] | Should -Be "https://example.com/wiki/rest/api/content?start=25"
         }
 
+        It "preserves GET parameters when following pagination links" {
+            $script:requestUris = @()
+            $script:invokeCount = 0
+            Mock Invoke-WebRequest -ModuleName ConfluencePS {
+                param($Uri)
+
+                $script:requestUris += $Uri.AbsoluteUri
+
+                if ($script:invokeCount -eq 0) {
+                    $script:invokeCount++
+                    return New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":1}],"_links":{"base":"https://example.com","next":"/wiki/rest/api/content?limit=20&start=20"}}'
+                }
+
+                New-FakeWebResponse -StatusCode 200 -Json '{"results":[{"id":2}]}'
+            }
+
+            $null = Invoke-Method -Uri "https://example.com/wiki/rest/api/content" -GetParameters @{
+                spaceKey = "Foo"
+                title    = "my Page"
+            } -ErrorAction Stop
+
+            $script:requestUris | Should -HaveCount 2
+            $nextUri = [uri]$script:requestUris[1]
+            $nextQueryParameters = [System.Web.HttpUtility]::ParseQueryString($nextUri.Query)
+            $nextQueryParameters["spaceKey"] | Should -Be "Foo"
+            $nextQueryParameters["title"] | Should -Be "my Page"
+            $nextQueryParameters["limit"] | Should -Be "20"
+            $nextQueryParameters["start"] | Should -Be "20"
+        }
+
         It "surfaces JSON errorMessages from HTTP error responses" {
             Mock Invoke-WebRequest -ModuleName ConfluencePS {
                 New-FakeWebResponse -StatusCode 400 -Json '{"errorMessages":["Alpha issue","Beta issue"]}'

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -468,6 +468,7 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
             $script:GetByQueryCanBeAsserted = $script:GetByQueryIndexed -or $script:GetByQueryRequired
             $script:GetSpacePage = Get-ConfluencePage -Space (Get-ConfluenceSpace -SpaceKey $SpaceKey) -ErrorAction SilentlyContinue
             $script:GetSpacePiped = Get-ConfluenceSpace -SpaceKey $SpaceKey | Get-ConfluencePage -ErrorAction SilentlyContinue
+            $script:GetSpacePaged = Get-ConfluencePage -SpaceKey $SpaceKey -PageSize 1 -ErrorAction SilentlyContinue
 
         }
 
@@ -489,6 +490,11 @@ Describe 'Integration Tests' -Tag Integration, Cloud, DataCenter {
                 @($GetByQuery).Count | Should -Be 2
             }
             @($GetSpacePiped).Count | Should -Be 5
+            @($GetSpacePaged).Count | Should -Be 5
+        }
+        It 'preserves the space filter when paginating page results' {
+            @($GetSpacePaged).Count | Should -Be 5
+            @($GetSpacePaged | Where-Object { $_.Space.Key -ne $SpaceKey }).Count | Should -Be 0
         }
         It 'returns an object with specific properties' {
             $GetTitle1 | Should -BeOfType [ConfluencePS.Page]


### PR DESCRIPTION
## Summary
- Preserve original GET filters when following Confluence pagination links
- Keep pagination-provided query values like start and limit intact
- Add unit regression coverage for paginated requests with spaceKey/title filters
- Add integration coverage that seeds the existing temporary test space and forces pagination with PageSize 1
- Preserve attachment download URLs when server information cannot be retrieved, fixing Data Center integration instability observed while validating this PR

Fixes #157

## Validation
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-157/ConfluencePS'; Invoke-Pester -Path 'Tests/Functions/Get-AttachmentFile.Tests.ps1'"
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-157/ConfluencePS'; Invoke-Pester -Path 'Tests/Functions/Invoke-Method.Tests.ps1'"
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-157/ConfluencePS'; Invoke-Build -Task Build, Test"
- Integration test command attempted locally: pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-157/ConfluencePS'; Invoke-Pester -Path 'Tests/Integration.Tests.ps1' -Tag Integration". It was blocked because this worktree has no Confluence integration .env/credentials configured.
- GitHub Actions run 26605009454: Cloud passed; new pagination integration test passed in Data Center; Data Center failed later in Get-ConfluenceAttachmentFile. Commit 8d445f8 addresses that server-info fallback failure.