### PR TITLE
Fix Get-ConfluenceSpace Data Center expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `Get-ConfluenceSpace` no longer requests unused space label metadata, avoiding HTTP 500 responses from Confluence Data Center 8.9.x when listing spaces (#214)
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])

--- a/ConfluencePS/Public/Get-Space.ps1
+++ b/ConfluencePS/Public/Get-Space.ps1
@@ -42,7 +42,7 @@
         $iwParameters = Copy-CommonParameter -InputObject $PSBoundParameters
         $iwParameters['Method'] = 'Get'
         $iwParameters['GetParameters'] = @{
-            expand = "description.plain,icon,homepage,metadata.labels"
+            expand = "description.plain,icon,homepage"
             limit  = $PageSize
         }
         $iwParameters['OutputType'] = [ConfluencePS.Space]

--- a/Tests/Configuration.Integration.Tests.ps1
+++ b/Tests/Configuration.Integration.Tests.ps1
@@ -93,6 +93,16 @@ Describe "Integration Test Configuration" -Tag 'Integration', 'Smoke', 'Cloud', 
             { Get-ConfluenceSpace -ErrorAction Stop | Select-Object -First 1 | Out-Null } | Should -Not -Throw
         }
 
+        It "can list spaces without expanded label metadata" {
+            if (-not $script:IsIntegrationEnvironmentConfigured) {
+                Set-ItResult -Skipped -Because "Environment not configured"
+                return
+            }
+
+            $spaces = Get-ConfluenceSpace -PageSize 1 -ErrorAction Stop
+            $spaces | Select-Object -First 1 | Should -BeOfType [ConfluencePS.Space]
+        }
+
         It "can execute a CQL page query using configured defaults" {
             if (-not $script:IsIntegrationEnvironmentConfigured) {
                 Set-ItResult -Skipped -Because "Environment not configured"

--- a/Tests/Configuration.Integration.Tests.ps1
+++ b/Tests/Configuration.Integration.Tests.ps1
@@ -99,8 +99,7 @@ Describe "Integration Test Configuration" -Tag 'Integration', 'Smoke', 'Cloud', 
                 return
             }
 
-            $spaces = Get-ConfluenceSpace -PageSize 1 -ErrorAction Stop
-            $spaces | Select-Object -First 1 | Should -BeOfType [ConfluencePS.Space]
+            { Get-ConfluenceSpace -PageSize 1 -ErrorAction Stop | Out-Null } | Should -Not -Throw
         }
 
         It "can execute a CQL page query using configured defaults" {

--- a/Tests/Functions/Get-Space.Tests.ps1
+++ b/Tests/Functions/Get-Space.Tests.ps1
@@ -1,0 +1,31 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment -CallerPath $PSScriptRoot
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope ConfluencePS {
+    Describe "Get-Space" -Tag 'Unit' {
+        BeforeEach {
+            $script:lastGetParameters = $null
+
+            Mock Invoke-Method -ModuleName ConfluencePS {
+                param(
+                    [hashtable]$GetParameters
+                )
+
+                $script:lastGetParameters = $GetParameters
+                [ConfluencePS.Space]::new()
+            }
+        }
+
+        It "does not request metadata labels when listing spaces" {
+            $null = Get-Space -ApiUri "https://example.com/wiki/rest/api"
+
+            $script:lastGetParameters['expand'] | Should -BeExactly "description.plain,icon,homepage"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove unused metadata.labels expansion from Get-ConfluenceSpace requests
- add a regression test for the generated space expand list
- document the fix in the changelog

Fixes #214

## Validation
- Invoke-Pester -Path 'Tests/Functions/Get-Space.Tests.ps1'
- Invoke-Build -Task Build, Test