### PR TITLE
Fix Set-ConfluenceInfo defaults inside functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.
+- `Set-ConfluenceInfo` now preserves configured defaults when called from inside another function (#199).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])
 - Fixed `-PersonalAccessToken` authentication on PowerShell 6+ by forwarding it as a bearer authorization header (#208, #209, [@sebmaurer])
 - Fixed Confluence Cloud attachment downloads on PowerShell 6+ by preserving authorization across Atlassian download redirects.
-- `Set-ConfluenceInfo` now preserves configured defaults when called from inside another function (#199).
+- `Set-ConfluenceInfo` now preserves configured defaults when called from inside another function (#199, [@lipkau]).
 
 ### Fixed
 

--- a/ConfluencePS/Public/Set-Info.ps1
+++ b/ConfluencePS/Public/Set-Info.ps1
@@ -33,9 +33,10 @@
             PROCESS {
                 Write-Verbose "[$($MyInvocation.MyCommand.Name)] Setting [$command : $parameter] = $value"
 
-                # Needs to set both global and module scope for the private functions:
+                # Needs to set caller, module, and global scope for nested functions and module commands:
                 # http://stackoverflow.com/questions/30427110/set-psdefaultparametersvalues-for-use-within-module-scope
                 $PSDefaultParameterValues["${command}:${parameter}"] = $Value
+                $script:PSDefaultParameterValues["${command}:${parameter}"] = $Value
                 $global:PSDefaultParameterValues["${command}:${parameter}"] = $Value
             }
         }

--- a/Tests/Functions/Get-Page.Tests.ps1
+++ b/Tests/Functions/Get-Page.Tests.ps1
@@ -62,5 +62,15 @@ InModuleScope ConfluencePS {
 
             Should -Invoke -CommandName Invoke-Method -ModuleName ConfluencePS -Exactly -Times 0 -Scope It
         }
+
+        It "sets prefixed defaults when called from inside a function" {
+            function Set-TestConfluenceDefaults {
+                Set-Info -BaseUri "https://example.com/wiki"
+            }
+
+            Set-TestConfluenceDefaults
+
+            $script:PSDefaultParameterValues["Get-ConfluencePage:ApiUri"] | Should -Be "https://example.com/wiki/rest/api"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Preserve Set-ConfluenceInfo defaults in module script scope so commands still bind defaults after Set-ConfluenceInfo is called from inside another function
- Add regression coverage for prefixed Get-ConfluencePage defaults
- Add an Unreleased changelog entry

Fixes #199

## Validation
- Invoke-Pester -Path 'Tests/Functions/Get-Page.Tests.ps1'
- Invoke-Build -Task Lint
- Invoke-Build -Task Build, Test