### PR TITLE
Fix Data Center attachment downloads when server info is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `Get-ConfluenceAttachmentFile` now preserves attachment download URLs when server information is unavailable, restoring Data Center attachment downloads in the Dockerized integration track.
 - `Get-ConfluenceSpace` no longer requests unused space label metadata, avoiding HTTP 500 responses from Confluence Data Center 8.9.x when listing spaces (#214)
 - `Get-ConfluencePage -Label` now quotes label values in generated CQL so labels containing hyphens are accepted by Confluence (#175, #185, [@ehrenfeu])
 - `Invoke-Method` now handles JSON payloads with duplicate key casing (for example `subType` and `subtype`) without failing parsing (#216, [@codethief])

--- a/ConfluencePS/Public/Get-AttachmentFile.ps1
+++ b/ConfluencePS/Public/Get-AttachmentFile.ps1
@@ -48,7 +48,13 @@
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
         $serverInfoParameters = Copy-CommonParameter -InputObject $PSBoundParameters
-        $serverInfo = Get-ServerInformation @serverInfoParameters -ApiUri $ApiUri -ErrorAction Stop
+        try {
+            $serverInfo = Get-ServerInformation @serverInfoParameters -ApiUri $ApiUri -ErrorAction Stop
+        }
+        catch {
+            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Server information unavailable; preserving attachment download URLs"
+            $serverInfo = $null
+        }
         $isCloudApi = $serverInfo.DeploymentType -eq 'Cloud'
     }
 

--- a/Tests/Functions/Get-AttachmentFile.Tests.ps1
+++ b/Tests/Functions/Get-AttachmentFile.Tests.ps1
@@ -86,6 +86,20 @@ InModuleScope ConfluencePS {
             }
         }
 
+        It "preserves attachment URLs when server information cannot be retrieved" {
+            $attachment = New-TestAttachment -URL "http://localhost:1990/confluence/download/attachments/123/Test.txt"
+
+            Mock Get-ServerInformation -ModuleName ConfluencePS { throw "systemInfo unavailable" }
+
+            $result = Get-AttachmentFile -ApiUri "http://localhost:1990/confluence/rest/api" -Attachment $attachment
+
+            $result | Should -Be $true
+            Should -Invoke -CommandName Invoke-Method -ModuleName ConfluencePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Uri -eq "http://localhost:1990/confluence/download/attachments/123/Test.txt" -and
+                $Headers.Accept -eq "*/*"
+            }
+        }
+
         It "retrieves server information only once for piped attachments" {
             $attachments = @(
                 New-TestAttachment -ID 456 -PageID 123 -URL "https://docs.example.com/wiki/download/attachments/123/Test1.txt"


### PR DESCRIPTION
## Summary
- keep Data Center attachment downloads on the attachment-provided URL when server information cannot be retrieved
- add a regression test for unavailable server information during `Get-ConfluenceAttachmentFile`
- document the fix in the changelog

## Context
The master Data Center integration lane is failing in `Integration Tests.Get-ConfluenceAttachmentFile` because the Dockerized Confluence instance returns 404 for `/settings/systemInfo`.

This is not just a Docker-specific assumption: the Confluence Cloud REST schema documents `/wiki/rest/api/settings/systemInfo`, while the static Confluence Server/Data Center REST docs checked for 8.9 do not expose `/rest/api/settings/systemInfo`. Attachment downloads should therefore not depend on server information being available for Data Center; preserving the attachment-provided URL is the existing Data Center behavior.

## Validation
- `Invoke-Pester -Path 'Tests/Functions/Get-AttachmentFile.Tests.ps1'`
- `Invoke-Build -Task Build, Test`
- CI: all required checks passed on PR #252
