### PR TITLE
docs: expose website command index and label title

### DIFF
--- a/docs/en-US/classes/ConfluencePS.Label.md
+++ b/docs/en-US/classes/ConfluencePS.Label.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+title: ConfluencePS.Label
 permalink: /docs/ConfluencePS/classes/ConfluencePS.Label/
 ---
 <!-- markdownlint-disable MD036 -->

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -1,7 +1,6 @@
 ---
 layout: documentation
 permalink: /docs/ConfluencePS/commands/
-hide: true
 ---
 # ConfluencePS commands
 


### PR DESCRIPTION
## Summary
- unhide the upstream ConfluencePS command index for generated website docs
- add the missing ConfluencePS.Label page title so generated docs render a valid title

## Validation
- documentation-only change
- rebased on current master
- validated through the AtlassianPS.github.io generated-site link audit