### PR TITLE
Clarify copyright attribution

### DIFF
--- a/ConfluencePS/ConfluencePS.psd1
+++ b/ConfluencePS/ConfluencePS.psd1
@@ -24,7 +24,7 @@
     CompanyName       = 'AtlassianPS'
 
     # Copyright statement for this module
-    Copyright         = 'MIT License'
+    Copyright         = '(c) 2016 Brian Bunke and AtlassianPS contributors.'
 
     # Description of the functionality provided by this module
     Description       = 'PowerShell module to interact with the Atlassian Confluence REST API'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Brian Bunke
+Copyright (c) 2016 AtlassianPS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- preserve Brian Bunke's original 2016 copyright notice
- add the `AtlassianPS contributors` group notice for later project contributions
- align the module manifest with both notices

This changes attribution metadata, not the MIT license terms.

## Validation

- `Test-ModuleManifest`
- `Invoke-Build -Task Lint`
- `Invoke-Build -Task Build, Test` — 173 passed
