### PR TITLE
Upgrade test infrastructure to Pester 5.9.x

### DIFF
--- a/.changelog/260.patch.changed.md
+++ b/.changelog/260.patch.changed.md
@@ -1,0 +1,1 @@
+* Standardized lint, unit, and integration test execution on Pester 5.9.x, using 5.9.0 as the clean-install baseline and 5.9.999 as the upper compatibility bound (#260, @lipkau).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - run: Invoke-Build -Task Lint, Build
         shell: pwsh
@@ -74,7 +74,7 @@ jobs:
             "tag=$($Matches.tag)" >> $env:GITHUB_OUTPUT
           }
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
         if: steps.release.outputs.tag != ''
         with:
           release-version: ${{ steps.release.outputs.tag }}
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
         with:
           ps-version: "5"
           skip-setup: "true"
@@ -139,7 +139,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -171,7 +171,7 @@ jobs:
       ATLASSIAN_CLOUD_PAT: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - name: Run smoke integration tests
         run: Invoke-Build -Task TestIntegration -Tag "Smoke" -PesterVerbosity Detailed

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
     with:
       module-name: ConfluencePS
       release-impact: ${{ inputs.release_impact }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
       ATLASSIAN_CLOUD_PAT: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - name: Run Cloud-tagged integration tests
         run: |
@@ -68,7 +68,7 @@ jobs:
         run: docker compose up -d
         shell: bash
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - name: Wait for Confluence to become reachable
         run: ./Tools/Wait-ConfluenceServer.ps1 -TimeoutSeconds 1500

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -13,4 +13,4 @@ jobs:
     name: Release Intent
     runs-on: ubuntu-latest
     steps:
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,7 @@
             "type": "PowerShell",
             "request": "launch",
             "name": "PowerShell Pester Tests",
-            "script": ".\\.env.ps1",
-            "script": "Invoke-Pester",
+            "script": "Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue; Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop; Invoke-Pester",
             "args": [],
             "cwd": "${workspaceRoot}"
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,7 @@
             "suppressTaskName": true,
             "isTestCommand": true,
             "args": [
-                "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
+                "Write-Host 'Invoking Pester'; Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue; Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
             ],
             "problemMatcher": "$pester"

--- a/ConfluencePS.build.ps1
+++ b/ConfluencePS.build.ps1
@@ -133,6 +133,9 @@ Task Lint {
     Remove-Item $env:BHBuildOutput -Force -Recurse -ErrorAction SilentlyContinue
     Remove-Item "Test*.xml" -Force -ErrorAction SilentlyContinue
 
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop
+
     $styleConfig = New-PesterConfiguration -Hashtable @{
         Run    = @{
             PassThru = $true
@@ -473,6 +476,9 @@ Task SetVersion {
 
 Task Test {
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
+
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop
 
     # Skip integration test files at discovery time so normal Test runs do
     # not execute setup blocks or require integration credentials.

--- a/Tests/Build.Tests.ps1
+++ b/Tests/Build.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Validation of build environment" -Tag Unit {
     BeforeAll {

--- a/Tests/ConfluencePS.Tests.ps1
+++ b/Tests/ConfluencePS.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Examples.Tests.ps1
+++ b/Tests/Examples.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/.template.ps1
+++ b/Tests/Functions/Private/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/.template.ps1
+++ b/Tests/Functions/Public/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/ConvertTo-StorageFormat.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertTo-StorageFormat.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/ConvertTo-Table.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertTo-Table.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'ConvertTo-Table' -Tag Unit {
 

--- a/Tests/Functions/Public/Get-AttachmentFile.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-AttachmentFile.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-ChildPage.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-ChildPage.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-Page.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Page.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-ServerInformation.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-ServerInformation.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-Space.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Space.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Invoke-Method.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-Method.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/PublicCmdletUnitCoverage.Unit.Tests.ps1
+++ b/Tests/Functions/Public/PublicCmdletUnitCoverage.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Functions/Public/Set-Page.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-Page.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'GitHub Actions release contract' -Tag Unit {
     BeforeAll {

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Integration/.template.ps1
+++ b/Tests/Integration/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/Attachments.Integration.Tests.ps1
+++ b/Tests/Integration/Attachments.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Integration/Configuration.Integration.Tests.ps1
+++ b/Tests/Integration/Configuration.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Integration/Labels.Integration.Tests.ps1
+++ b/Tests/Integration/Labels.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Integration/Pages.Integration.Tests.ps1
+++ b/Tests/Integration/Pages.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Integration/Spaces.Integration.Tests.ps1
+++ b/Tests/Integration/Spaces.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 param()
 

--- a/Tests/Invoke-ParallelPester.ps1
+++ b/Tests/Invoke-ParallelPester.ps1
@@ -80,7 +80,8 @@ try {
         Read-DotEnvFile -Path (Join-Path $projectRoot '.env') -ExcludeName (Get-DotEnvExcludedName)
     }
 
-    Import-Module Pester -MinimumVersion 5.0 -Force
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop
     Set-Location $projectRoot
 
     $config = New-PesterConfiguration

--- a/Tests/PSScriptAnalyzer.Tests.ps1
+++ b/Tests/PSScriptAnalyzer.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 #requires -modules PSScriptAnalyzer
 
 BeforeDiscovery {

--- a/Tests/Project.Tests.ps1
+++ b/Tests/Project.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"
@@ -6,10 +6,14 @@ BeforeDiscovery {
     $script:moduleToTest = Initialize-TestEnvironment
     $script:moduleRoot = Resolve-ProjectRoot
 
-    Import-Module $moduleToTest -Force -ErrorAction Stop
+    Import-Module $moduleToTest -Global -Force -ErrorAction Stop
 }
 
 Describe "General project validation" -Tag Unit {
+    BeforeAll {
+        Import-Module $moduleToTest -Global -Force -ErrorAction Stop
+    }
+
     BeforeDiscovery {
         $script:module = Get-Module 'ConfluencePS'
 
@@ -46,11 +50,12 @@ Describe "General project validation" -Tag Unit {
             }
 
             It "is loaded in the module" {
-                $commandInModule = $module.Invoke({
-                        param($name)
-                        Get-Command -Name $name -CommandType Function -ErrorAction SilentlyContinue |
-                            Where-Object { $_.ModuleName -eq 'ConfluencePS' }
-                    }, $functionName)
+                $commandInModule = InModuleScope ConfluencePS -Parameters @{ Name = $functionName } {
+                    param($Name)
+
+                    Get-Command -Name $Name -CommandType Function -ErrorAction SilentlyContinue |
+                        Where-Object { $_.ModuleName -eq 'ConfluencePS' }
+                }
 
                 $commandInModule | Should -Not -BeNullOrEmpty -Because "private function '$functionName' should be loaded"
             }

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -4,7 +4,7 @@ This guide explains the test layout used by ConfluencePS.
 
 ## Test Structure
 
-ConfluencePS uses Pester 5.7+ for new and modernized tests.
+ConfluencePS uses Pester 5.9.x for new and modernized tests.
 Tests are organized to mirror the module structure:
 
 - `Tests/Functions/Public/` contains unit tests for exported cmdlets in `ConfluencePS/Public/`.

--- a/Tests/Style.Tests.ps1
+++ b/Tests/Style.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Style rules" -Tag "Unit" {
     BeforeAll {

--- a/Tests/Tools/SetupScript.Unit.Tests.ps1
+++ b/Tests/Tools/SetupScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "4.10" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/setup.ps1' -Tag Unit {
     BeforeAll {

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -1,10 +1,10 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
         $script:projectRoot = Resolve-ProjectRoot
-        $script:standardsActionSha = '869d36f403c7534a37434d64119f96d1bacfeb25'
+        $script:standardsActionSha = 'fc574a6647971312d28383dd06e29a1a8d2e66e6'
 
         $requirements = Import-PowerShellDataFile -Path (Join-Path $script:projectRoot 'Tools/build.requirements.psd1')
         $standardsRequirement = $requirements |

--- a/Tests/Tools/Update-DependenciesScript.Unit.Tests.ps1
+++ b/Tests/Tools/Update-DependenciesScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "4.10" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/update.dependencies.ps1' -Tag Unit {
     BeforeAll {

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,8 +1,8 @@
 @(
-    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.17" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.18" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
-    @{ ModuleName = "Pester"; RequiredVersion = "5.7.1" }
+    @{ ModuleName = "Pester"; RequiredVersion = "5.9.0" }
     @{ ModuleName = "Microsoft.PowerShell.PlatyPS"; RequiredVersion = "1.0.1" }
     @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.25.0" }
 )


### PR DESCRIPTION
## Summary

- Install Pester 5.9.0 and bound lint, unit, integration, and VS Code execution at 5.9.999.
- Replace private-command discovery through `module.Invoke` with `InModuleScope`.
- Pin AtlassianPS.Standards v0.1.18 and provide a typed changelog fragment for the automatic release test.

## Why

Pester 5.9.0 is the reproducible clean-install baseline. The 5.9.999 maximum accepts compatible 5.9.x patches without allowing an unreviewed future major version to change test behavior.

This applies the lessons from AtlassianPS/JiraAgilePS#43 and serves as the first normal post-rollout automatic release.

## Validation

- `actionlint .github/workflows/*.yml`
- Focused workflow and Standards consistency tests: 9 passed
- `Invoke-Build -Task Build, Test` with the published Standards v0.1.18 artifact: 180 passed
- Cloud and Data Center integration are green ([run 32740266853](https://github.com/AtlassianPS/ConfluencePS/actions/runs/32740266853))