### PR TITLE
Fix release planner label access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
 
       - run: Invoke-Build -Task Lint, Build
         shell: pwsh
@@ -74,7 +74,7 @@ jobs:
             "tag=$($Matches.tag)" >> $env:GITHUB_OUTPUT
           }
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
         if: steps.release.outputs.tag != ''
         with:
           release-version: ${{ steps.release.outputs.tag }}
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
         with:
           ps-version: "5"
           skip-setup: "true"
@@ -139,7 +139,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -171,7 +171,7 @@ jobs:
       ATLASSIAN_CLOUD_PAT: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
 
       - name: Run smoke integration tests
         run: Invoke-Build -Task TestIntegration -Tag "Smoke" -PesterVerbosity Detailed

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -18,11 +18,12 @@ on:
 permissions:
   actions: read
   contents: read
+  issues: read
   pull-requests: read
 
 jobs:
   release:
-    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
     with:
       module-name: ConfluencePS
       release-impact: ${{ inputs.release_impact }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
       ATLASSIAN_CLOUD_PAT: ${{ secrets.ATLASSIAN_CLOUD_PAT }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
 
       - name: Run Cloud-tagged integration tests
         run: |
@@ -68,7 +68,7 @@ jobs:
         run: docker compose up -d
         shell: bash
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17
 
       - name: Wait for Confluence to become reachable
         run: ./Tools/Wait-ConfluenceServer.ps1 -TimeoutSeconds 1500

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -13,4 +13,4 @@ jobs:
     name: Release Intent
     runs-on: ubuntu-latest
     steps:
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@869d36f403c7534a37434d64119f96d1bacfeb25 # v0.1.17

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
         $script:projectRoot = Resolve-ProjectRoot
-        $script:standardsActionSha = '3c050eda17bfb4177f93c3cac61610a6f21b2537'
+        $script:standardsActionSha = '869d36f403c7534a37434d64119f96d1bacfeb25'
 
         $requirements = Import-PowerShellDataFile -Path (Join-Path $script:projectRoot 'Tools/build.requirements.psd1')
         $standardsRequirement = $requirements |

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,5 +1,5 @@
 @(
-    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.16" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.17" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Pester"; RequiredVersion = "5.7.1" }


### PR DESCRIPTION
## Summary

- Repin all Standards actions and the reusable release workflow to `v0.1.17` (`869d36f403c7534a37434d64119f96d1bacfeb25`).
- Grant `issues: read` to the continuous-release caller so the reusable planner can read merged PR labels.
- Align the local Standards build dependency and consistency test with `0.1.17`.

## Context

The first ConfluencePS centralized release run reached the shared planner but `GITHUB_TOKEN` returned no labels from the issues labels API. Standards PR #50 fixes the reusable workflow permission; this PR supplies the matching caller permission and immutable pin.

## Validation

- `actionlint .github/workflows/*.yml`
- 9 focused workflow and Standards consistency tests
- `Invoke-Build -Task Lint, Build, Test` — 180 tests passed using the published `v0.1.17` GitHub release artifact
- `git diff --check`
