### PR TITLE
Reduce scheduled GitHub Actions runs

### DIFF
--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -87,6 +87,6 @@ DataCenter track requires `CI_CONFLUENCE_TYPE=DataCenter`, `CI_CONFLUENCE_URL`, 
 - User-facing command docs belong in `docs/en-US/commands/*.md`.
 - Include changelog updates for user-visible behavior changes.
 - `.github/workflows/ci.yml` path filters can skip instruction-only changes.
-- `.github/workflows/integration_tests.yml` is the full-suite Cloud/Data Center integration workflow (nightly + manual).
+- `.github/workflows/integration_tests.yml` is the full-suite Cloud/Data Center integration workflow (weekly + manual).
 - `.github/ai-context/releasing.md` links to the canonical AtlassianPS Standards release blueprint and keeps ConfluencePS-specific release details.
 - Run local validation before opening/updating PRs when changing instruction files.

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
+    branches: [master]
   workflow_dispatch:
     inputs:
       release_impact:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,10 +1,10 @@
 name: Integration Tests
 
-# Cloud + Data Center tracks share this workflow's nightly cron and manual
+# Cloud + Data Center tracks share this workflow's weekly cron and manual
 # dispatch but run independently in parallel jobs.
 on:
   schedule:
-    - cron: "0 5 * * *"
+    - cron: "0 5 * * 0"
   workflow_dispatch:
     inputs:
       track:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Before merging: ensure the Windows PowerShell 5.1 CI test job is green.
 ## CI/CD Alignment
 
 - `.github/workflows/ci.yml` is the required PR/push quality gate.
-- `.github/workflows/integration_tests.yml` runs full integration suites on a nightly schedule (Cloud + Dockerized Data Center) and manual dispatch.
+- `.github/workflows/integration_tests.yml` runs full integration suites weekly (Cloud + Dockerized Data Center) and by manual dispatch.
 - `.github/workflows/release_intent.yml` validates release labels and changelog fragments.
 - `.github/workflows/continuous_release.yml` delegates release orchestration to the pinned reusable Standards workflow.
 - `.github/ai-context/releasing.md` keeps ConfluencePS-specific release steps and links to the canonical AtlassianPS Standards release blueprint.

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -7,6 +7,7 @@ Describe 'GitHub Actions release contract' -Tag Unit {
         $workflowRoot = Join-Path $script:projectRoot '.github/workflows'
         $script:ci = Get-Content (Join-Path $workflowRoot 'ci.yml') -Raw
         $script:continuousRelease = Get-Content (Join-Path $workflowRoot 'continuous_release.yml') -Raw
+        $script:integrationTests = Get-Content (Join-Path $workflowRoot 'integration_tests.yml') -Raw
         $script:releaseIntent = Get-Content (Join-Path $workflowRoot 'release_intent.yml') -Raw
     }
 
@@ -38,11 +39,17 @@ Describe 'GitHub Actions release contract' -Tag Unit {
     }
 
     It 'delegates release orchestration to the immutable Standards workflow' {
+        $script:continuousRelease | Should -Match '(?ms)workflow_run:.*?branches:\s*\[master\]'
         $script:continuousRelease | Should -Match 'uses:\s+AtlassianPS/AtlassianPS\.Standards/\.github/workflows/module_release\.yml@[0-9a-f]{40}'
         $script:continuousRelease | Should -Match 'module-name:\s+ConfluencePS'
         $script:continuousRelease | Should -Match 'release-impact:\s+\$\{\{\s*inputs\.release_impact\s*\}\}'
         $script:continuousRelease | Should -Match 'secrets:\s+inherit'
         $script:continuousRelease | Should -Not -Match '(?m)^  (prepare|publish):|Publish-Module|create-github-app-token|actions/download-artifact'
+    }
+
+    It 'runs full integration tests weekly and on demand' {
+        $script:integrationTests | Should -Match 'cron:\s*"0 5 \* \* 0"'
+        $script:integrationTests | Should -Match 'workflow_dispatch:'
     }
 
     It 'removes the legacy tag-triggered release path' {


### PR DESCRIPTION
## Summary

- Run full Cloud and Data Center integration suites weekly on Sunday instead of nightly.
- Filter Continuous Release to completed CI runs on master.
- Update workflow documentation and contract tests.

## Why

PR and push CI retain the existing smoke and platform coverage. Weekly full integration runs preserve drift detection while reducing scheduled runner use.

## Validation

- actionlint passed for both changed workflows.
- Workflow contract tests: 8 passed.
- Invoke-Build -Task Build, Test: 181 passed.

## Related pull requests

- AtlassianPS.Configuration: https://github.com/AtlassianPS/AtlassianPS.Configuration/pull/45
- AtlassianPS.Standards: https://github.com/AtlassianPS/AtlassianPS.Standards/pull/56
- ConfluencePS: https://github.com/AtlassianPS/ConfluencePS/pull/264
- JiraAgilePS: https://github.com/AtlassianPS/JiraAgilePS/pull/49
- JiraPS: https://github.com/AtlassianPS/JiraPS/pull/711