### PR TITLE
Reduce integration workflow artifact usage

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,6 +16,11 @@ on:
           - cloud
           - datacenter
           - both
+      debug:
+        description: "Upload Data Center container logs even when tests succeed"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,6 +51,7 @@ jobs:
         with:
           name: Cloud-Integration-Tests
           path: Test-Integration.xml
+          retention-days: 14
         if: always()
 
   datacenter_integration_tests:
@@ -84,10 +90,11 @@ jobs:
         with:
           name: DataCenter-Integration-Tests
           path: Test-Integration.xml
+          retention-days: 14
         if: always()
 
       - name: Capture Confluence container logs for debugging
-        if: always()
+        if: ${{ failure() || inputs.debug || runner.debug == '1' }}
         run: docker compose logs confluence > confluence-container.log
         shell: bash
 
@@ -95,7 +102,8 @@ jobs:
         with:
           name: DataCenter-Confluence-Container-Logs
           path: confluence-container.log
-        if: always()
+          retention-days: 7
+        if: ${{ failure() || inputs.debug || runner.debug == '1' }}
 
       - name: Tear down Confluence Data Center container
         if: always()

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -2,7 +2,7 @@ name: Release Intent
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   pull-requests: read

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -24,6 +24,10 @@ Describe 'GitHub Actions release contract' -Tag Unit {
 
     It 'validates release intent without checking out contributor code' {
         $script:releaseIntent | Should -Match '(?m)^\s+pull_request_target:'
+        $script:releaseIntent | Should -Not -Match '(?m)types:\s*\[[^\]]*\bedited\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\bsynchronize\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\blabeled\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\bunlabeled\b'
         $script:releaseIntent | Should -Match 'AtlassianPS/AtlassianPS\.Standards/\.github/actions/validate-release-intent@'
         $script:releaseIntent | Should -Match '(?m)^\s+pull-requests:\s+read\r?$'
         $script:releaseIntent | Should -Match '(?m)^\s+issues:\s+write\r?$'
@@ -50,6 +54,13 @@ Describe 'GitHub Actions release contract' -Tag Unit {
     It 'runs full integration tests weekly and on demand' {
         $script:integrationTests | Should -Match 'cron:\s*"0 5 \* \* 0"'
         $script:integrationTests | Should -Match 'workflow_dispatch:'
+    }
+
+    It 'retains integration diagnostics briefly and uploads container logs on demand' {
+        ([regex]::Matches($script:integrationTests, 'retention-days:\s+14')).Count | Should -Be 2
+        ([regex]::Matches($script:integrationTests, 'retention-days:\s+7')).Count | Should -Be 1
+        $script:integrationTests | Should -Match '(?ms)debug:.*?type:\s+boolean'
+        ([regex]::Matches($script:integrationTests, "failure\(\) \|\| inputs\.debug \|\| runner\.debug == '1'")).Count | Should -Be 2
     }
 
     It 'removes the legacy tag-triggered release path' {


### PR DESCRIPTION
## Summary

- remove title/body edits from release-intent triggers
- retain integration results for 14 days and container logs for 7 days
- upload successful Data Center logs only when manual debug or runner debug is enabled
- preserve failure log collection

## Validation

- actionlint
- focused GitHub Actions tests: 9 passed
- full Build and Test: 182 passed

## Related pull requests

- AtlassianPS.Configuration #46
- AtlassianPS.Standards #57
- AtlassianPS.github.io #61
- ConfluencePS #265
- JiraAgilePS #50
- JiraPS #713