### PR TITLE
Document pull request release intent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Description
+
+<!-- Describe the change and why it is needed. -->
+
+### Release intent
+
+<!-- Maintainers apply exactly one release label: release:none, release:patch, release:minor, or release:major. -->
+<!-- A releasing PR also needs one changelog:* label or one .changelog/<pr>.<impact>.<type>.md fragment. -->
+
+- [ ] This change needs no independent package release (`release:none`).
+- [ ] This change needs a patch, minor, or major release and includes release-note intent.
+
+### Validation
+
+- [ ] I ran the relevant focused tests.
+- [ ] I ran `Invoke-Build -Task Build, Test`, or explained why it was not applicable.
+- [ ] I updated user documentation for user-visible behavior.
+- [ ] I checked both Cloud and Data Center behavior when API behavior changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ Before merging: ensure the Windows PowerShell 5.1 CI test job is green.
 - `.github/workflows/release_intent.yml` validates release labels and changelog fragments.
 - `.github/workflows/continuous_release.yml` delegates release orchestration to the pinned reusable Standards workflow.
 - `.github/ai-context/releasing.md` keeps ConfluencePS-specific release steps and links to the canonical AtlassianPS Standards release blueprint.
+- Branch protection requires both `CI Result` and `Release Intent` before merge.
 - For instruction-only changes, run local validation before opening/updating a PR.
 
 ## Instruction Maintenance


### PR DESCRIPTION
## Summary

- add a contributor-facing pull request template with release-intent guidance
- record the required Release Intent branch-protection check

## Validation

- Invoke-Build -Task Build, Test (181 passed)
- git diff --check